### PR TITLE
META: add autonomous scheduler boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ packages/                       # TypeScript monorepo (pnpm workspaces)
   coverage-gates/               # §6: Gate 1, Gate 2, Gate 3 (fail-closed)
   assurance-graph/              # §5: incident propagation via typed dependencies
   runtime/                      # Stage 7: trust, invariant health, regression
-  # Stage 6 coordinator — pending fresh meta-PRD authored per whitepaper §3
+  autonomous-scheduler/          # Stage 6 boundary: WorkGraph → AgentRequest → evidence
 
 specs/                          # Factory artifacts (Factory-built-by-Factory)
   signals/                      # Stage 1 input (ExternalSignal, SIG-*)

--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -1,0 +1,94 @@
+# Autonomous Factory Transition
+
+This document defines the transition from manual Codex operation to Function
+Factory as the autonomous scheduler for coding work.
+
+## Target Operating Model
+
+Function Factory is the control plane. Codex is a worker runtime.
+
+The steady-state loop is:
+
+1. Governor reads Factory artifacts and selects the next admissible WorkGraph node.
+2. Scheduler converts the node into a role-scoped `AgentRequest`.
+3. Queue persists the request and emits `QueueEvent` records.
+4. Codex runner claims one request in a clean session.
+5. Runner creates a PR branch, implements within `allowedPaths`, runs required commands, and returns `AgentResult`.
+6. Critic, tester, verifier, and coverage gates evaluate evidence.
+7. Governor either advances the WorkGraph, emits follow-up requests, or blocks for a human decision.
+
+## Runtime Boundary
+
+The boundary is explicit so the Factory can drive multiple worker backends later:
+
+1. `AgentRequest` is the only way to ask a worker to act.
+2. `AgentResult` is the only way for a worker to report completion.
+3. `QueueEvent` is the durable audit stream for queue behavior.
+
+Worker internals are replaceable. The contract is not.
+
+## Autonomy Levels
+
+Level 0: Manual
+
+Codex acts directly. Factory artifacts are consulted by humans and operators.
+
+Level 1: Recommend Only
+
+Governor proposes the next request, but no queue item is written.
+
+Level 2: Enqueue Only
+
+Governor writes `AgentRequest` records. A human manually launches workers.
+
+Level 3: Branch PR
+
+Workers claim queue items, create branches, open PRs, and return evidence. Human
+approval is still required for merge, deploy, and secrets.
+
+Level 4: Multi-Agent PR
+
+Architect, builder, tester, critic, and verifier requests can run as a coordinated
+set against the same WorkGraph node. Merge remains human-approved.
+
+Level 5: Reserved
+
+Auto-merge or production deploy requires a later ADR and stronger policy gates.
+
+## First Dogfood Workload
+
+Strategy.Recipes is the first external product workload.
+
+The initial request fixture is:
+
+`packages/autonomous-scheduler/fixtures/strategy-recipes-agent-request.json`
+
+It asks a builder worker to implement the first Strategy.Recipes product view
+from `Strategy_Recipes_UX_Architecture_v1.1.md` in a separate repo and PR branch.
+
+## Production Alpha Exit Criteria
+
+Function Factory reaches production alpha autonomy when:
+
+1. The queue persists `AgentRequest`, claim, heartbeat, result, and dead-letter records.
+2. The Codex runner can claim one request and return a validated `AgentResult`.
+3. PR/branch mode is enforced by policy before execution begins.
+4. Required command output is captured as evidence.
+5. Critic and verifier results are linked back to the originating WorkGraph node.
+6. The operator cockpit can show active queue, latest run, latest evidence, and blocked decisions.
+7. A Strategy.Recipes vertical slice is built through the queue rather than by manual Codex task selection.
+
+## Immediate Implementation Sequence
+
+1. Contract package: `@factory/autonomous-scheduler`.
+2. JSONL queue using the contract package.
+3. Codex runner adapter that claims one request and opens a PR branch.
+4. Governor scheduler that emits one Strategy.Recipes dogfood request.
+5. Critic/verifier requests generated from the builder result.
+6. Cockpit views over queue state and evidence.
+
+Steps 1 and 2 are bootstrapped by the initial autonomous scheduler contract
+slice. The Codex runner planning adapter is also bootstrapped: it validates an
+`AgentRequest`, derives the PR branch, emits git preflight commands, and builds
+the Codex worker prompt. The next production-alpha slice is the process-spawning
+runner that executes this plan and writes a validated `AgentResult`.

--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -95,6 +95,8 @@ converts runner evidence into a validated `AgentResult`, and writes durable
 artifact bundles. Pull request creation is wired through the same command seam
 using `gh pr create`. The single-request Governor path is bootstrapped by
 `runSingleAgentRequest`, which enqueues, claims, runs, opens a PR, writes a
-bundle, and completes the queue item. The next production-alpha slice is the CLI
-or daemon entrypoint that invokes this path against a real Strategy.Recipes
-checkout.
+bundle, and completes the queue item. The CLI entrypoint is
+`pnpm run autonomous-scheduler:cli -- ...`; it can validate, enqueue, claim,
+status, plan, and explicitly run a single request against a real checkout. The
+next production-alpha slice is the daemon that invokes the same path repeatedly
+with leases, heartbeats, and stop controls.

--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -92,4 +92,6 @@ slice. The Codex runner adapter is also bootstrapped: it validates an
 `AgentRequest`, derives the PR branch, emits git preflight commands, builds the
 Codex worker prompt, executes the command plan through an injectable executor,
 converts runner evidence into a validated `AgentResult`, and writes durable
-artifact bundles. The next production-alpha slice is wiring PR creation.
+artifact bundles. Pull request creation is wired through the same command seam
+using `gh pr create`. The next production-alpha slice is the Governor scheduler
+that emits and drives the Strategy.Recipes dogfood request end-to-end.

--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -88,7 +88,8 @@ Function Factory reaches production alpha autonomy when:
 6. Cockpit views over queue state and evidence.
 
 Steps 1 and 2 are bootstrapped by the initial autonomous scheduler contract
-slice. The Codex runner planning adapter is also bootstrapped: it validates an
-`AgentRequest`, derives the PR branch, emits git preflight commands, and builds
-the Codex worker prompt. The next production-alpha slice is the process-spawning
-runner that executes this plan and writes a validated `AgentResult`.
+slice. The Codex runner adapter is also bootstrapped: it validates an
+`AgentRequest`, derives the PR branch, emits git preflight commands, builds the
+Codex worker prompt, and executes the command plan through an injectable executor.
+The next production-alpha slice is converting runner command evidence into a
+validated `AgentResult` and PR artifact bundle.

--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -99,4 +99,5 @@ bundle, and completes the queue item. The CLI entrypoint is
 `pnpm run autonomous-scheduler:cli -- ...`; it can validate, enqueue, claim,
 status, plan, and explicitly run a single request against a real checkout. The
 next production-alpha slice is the daemon that invokes the same path repeatedly
-with leases, heartbeats, and stop controls.
+with stop controls. Queue leases and heartbeats are already part of the JSONL
+queue boundary, so a daemon can safely reclaim expired worker claims.

--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -93,5 +93,8 @@ slice. The Codex runner adapter is also bootstrapped: it validates an
 Codex worker prompt, executes the command plan through an injectable executor,
 converts runner evidence into a validated `AgentResult`, and writes durable
 artifact bundles. Pull request creation is wired through the same command seam
-using `gh pr create`. The next production-alpha slice is the Governor scheduler
-that emits and drives the Strategy.Recipes dogfood request end-to-end.
+using `gh pr create`. The single-request Governor path is bootstrapped by
+`runSingleAgentRequest`, which enqueues, claims, runs, opens a PR, writes a
+bundle, and completes the queue item. The next production-alpha slice is the CLI
+or daemon entrypoint that invokes this path against a real Strategy.Recipes
+checkout.

--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -98,6 +98,6 @@ using `gh pr create`. The single-request Governor path is bootstrapped by
 bundle, and completes the queue item. The CLI entrypoint is
 `pnpm run autonomous-scheduler:cli -- ...`; it can validate, enqueue, claim,
 status, plan, and explicitly run a single request against a real checkout. The
-next production-alpha slice is the daemon that invokes the same path repeatedly
-with stop controls. Queue leases and heartbeats are already part of the JSONL
-queue boundary, so a daemon can safely reclaim expired worker claims.
+daemon entrypoint repeats the same path over queued work with bounded polling,
+leases, heartbeats, and stop controls. Queue leases and heartbeats are part of
+the JSONL queue boundary, so the daemon can safely reclaim expired worker claims.

--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -101,3 +101,5 @@ status, plan, and explicitly run a single request against a real checkout. The
 daemon entrypoint repeats the same path over queued work with bounded polling,
 leases, heartbeats, and stop controls. Queue leases and heartbeats are part of
 the JSONL queue boundary, so the daemon can safely reclaim expired worker claims.
+The CLI supports `--dry-run` on `run-single` and `daemon` to exercise the full
+scheduler loop without invoking real `git`, `codex`, or `gh`.

--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -90,6 +90,7 @@ Function Factory reaches production alpha autonomy when:
 Steps 1 and 2 are bootstrapped by the initial autonomous scheduler contract
 slice. The Codex runner adapter is also bootstrapped: it validates an
 `AgentRequest`, derives the PR branch, emits git preflight commands, builds the
-Codex worker prompt, and executes the command plan through an injectable executor.
-The next production-alpha slice is converting runner command evidence into a
-validated `AgentResult` and PR artifact bundle.
+Codex worker prompt, executes the command plan through an injectable executor,
+and converts runner evidence into a validated `AgentResult`. The next
+production-alpha slice is writing the artifact bundle contents to disk and
+wiring PR creation.

--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -91,6 +91,5 @@ Steps 1 and 2 are bootstrapped by the initial autonomous scheduler contract
 slice. The Codex runner adapter is also bootstrapped: it validates an
 `AgentRequest`, derives the PR branch, emits git preflight commands, builds the
 Codex worker prompt, executes the command plan through an injectable executor,
-and converts runner evidence into a validated `AgentResult`. The next
-production-alpha slice is writing the artifact bundle contents to disk and
-wiring PR creation.
+converts runner evidence into a validated `AgentResult`, and writes durable
+artifact bundles. The next production-alpha slice is wiring PR creation.

--- a/docs/adr/ADR-0001-autonomous-scheduler-boundary.md
+++ b/docs/adr/ADR-0001-autonomous-scheduler-boundary.md
@@ -1,0 +1,88 @@
+# ADR-0001: Autonomous Scheduler Boundary
+
+Status: Accepted
+
+Date: 2026-04-30
+
+## Context
+
+Function Factory must become the autonomous product/platform that schedules and
+verifies coding work. Codex is not the product. Codex is a runtime worker that
+Function Factory can launch, constrain, and evaluate.
+
+Strategy.Recipes is a separate product/platform workload. Function Factory v1.0
+must be able to build Strategy.Recipes from Factory artifacts without the human
+or this chat session manually deciding each implementation step.
+
+The prior manual workflow was useful for bootstrapping, but it inverted the
+target architecture:
+
+1. Human or Codex selected the next task.
+2. Codex implemented directly.
+3. Factory artifacts were consulted or updated afterward.
+
+The target workflow reverses this:
+
+1. Function Factory selects a WorkGraph node.
+2. The Governor emits an `AgentRequest`.
+3. A queue persists the request.
+4. A Codex runner claims the request in a fresh branch/session.
+5. The runner returns an `AgentResult` with PR, diff, test, and artifact evidence.
+6. Critic, tester, verifier, and coverage components decide whether the graph can advance.
+
+## Decision
+
+Function Factory owns the scheduling boundary. Codex runners are stateless
+workers behind a durable queue contract.
+
+The initial production posture is PR/branch mode:
+
+1. Workers may create branches and pull requests.
+2. Workers may only modify declared repo-relative `allowedPaths`.
+3. Workers may not merge default branches.
+4. Workers may not deploy to production.
+5. Workers may not force-push.
+6. Workers may not edit secrets.
+7. Completed work must return evidence before the Governor advances the WorkGraph.
+
+The first contracts are:
+
+1. `AgentRequest`: work assigned from a WorkGraph node to a role-specific worker.
+2. `AgentResult`: worker evidence returned after implementation or refusal.
+3. `QueueEvent`: append-only event emitted at the queue boundary.
+
+These contracts live in `@factory/autonomous-scheduler`.
+
+## Consequences
+
+Function Factory can dogfood external repo builds without allowing uncontrolled
+mutation. Strategy.Recipes becomes a workload target, not a dependency of
+Function Factory.
+
+Autonomy increases by moving from `recommend_only` to `enqueue_only` to
+`branch_pr` to `multi_agent_pr`. Auto-merge is intentionally not part of the
+initial contract.
+
+The Governor and operator cockpit can display queue state, active claims,
+returned evidence, and blocked decisions without needing to understand Codex
+session internals.
+
+## Non-Goals
+
+This ADR does not implement the long-running runner daemon.
+
+This ADR does not implement auto-merge.
+
+This ADR does not make Strategy.Recipes part of the Function Factory repo.
+
+This ADR does not replace the Factory artifact pipeline. It adds an execution
+boundary downstream of WorkGraphs.
+
+## Source Inputs
+
+1. Operator directive on 2026-04-30: Function Factory must autonomously drive
+   Codex as a runtime scheduler.
+2. `FF-CLI-DESIGN-V2.md`: terminal UX and Governor/operator interaction model.
+3. `Strategy_Recipes_UX_Architecture_v1.1.md`: first external product workload.
+4. Prior Ralph Wiggum loop analysis: fresh worker sessions, durable task state,
+   small tasks, evidence-backed exits.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "policy-activation:typecheck": "pnpm --filter @factory/policy-activation run typecheck",
     "autonomous-scheduler:test": "pnpm --filter @factory/autonomous-scheduler run test",
     "autonomous-scheduler:typecheck": "pnpm --filter @factory/autonomous-scheduler run typecheck",
+    "autonomous-scheduler:cli": "tsx packages/autonomous-scheduler/src/cli.ts",
     "dream": "tsx .agent/tools/dream.ts",
     "bootstrap": "tsx scripts/bootstrap.ts"
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "meta-governance:typecheck": "pnpm --filter @factory/meta-governance run typecheck",
     "policy-activation:test": "pnpm --filter @factory/policy-activation run test",
     "policy-activation:typecheck": "pnpm --filter @factory/policy-activation run typecheck",
+    "autonomous-scheduler:test": "pnpm --filter @factory/autonomous-scheduler run test",
+    "autonomous-scheduler:typecheck": "pnpm --filter @factory/autonomous-scheduler run typecheck",
     "dream": "tsx .agent/tools/dream.ts",
     "bootstrap": "tsx scripts/bootstrap.ts"
   },

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -40,3 +40,14 @@ also planned and executed through the same command seam using `gh pr create`.
 4. Create a PR if the runner succeeds.
 5. Build and persist a validated `AgentResult` bundle.
 6. Complete the queue item with pass/fail evidence.
+
+CLI entrypoint:
+
+```bash
+pnpm run autonomous-scheduler:cli -- validate-request packages/autonomous-scheduler/fixtures/strategy-recipes-agent-request.json
+pnpm run autonomous-scheduler:cli -- enqueue /tmp/factory-queue packages/autonomous-scheduler/fixtures/strategy-recipes-agent-request.json
+pnpm run autonomous-scheduler:cli -- status /tmp/factory-queue
+```
+
+`run-single` is intentionally explicit because it executes `git`, `codex`, and
+`gh` against the requested repo.

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -41,6 +41,9 @@ also planned and executed through the same command seam using `gh pr create`.
 5. Build and persist a validated `AgentResult` bundle.
 6. Complete the queue item with pass/fail evidence.
 
+`runQueueDaemon` repeats the same path for queued work with bounded polling,
+claim leases, heartbeats, and stop predicates.
+
 CLI entrypoint:
 
 ```bash
@@ -49,8 +52,8 @@ pnpm run autonomous-scheduler:cli -- enqueue /tmp/factory-queue packages/autonom
 pnpm run autonomous-scheduler:cli -- status /tmp/factory-queue
 ```
 
-`run-single` is intentionally explicit because it executes `git`, `codex`, and
-`gh` against the requested repo.
+`run-single` and `daemon` are intentionally explicit because they execute `git`,
+`codex`, and `gh` against the requested repo.
 
 Queue claims include leases and heartbeats. Expired claims can be reclaimed by a
 later runner; active claims are excluded from pending queue counts.

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -18,11 +18,15 @@ The initial operational posture is PR/branch mode. Direct default-branch
 mutation, production deploys, force-pushes, and secret edits are explicitly
 outside the permitted contract.
 
-The Codex runner adapter currently plans execution instead of spawning a process:
+The Codex runner adapter currently plans and can execute commands through an
+injectable executor:
 
 1. Validate the `AgentRequest`.
 2. Derive the PR branch name.
 3. Produce git preflight commands.
 4. Build the Codex worker prompt with policy, context, commands, and evidence requirements.
+5. Execute the plan sequentially, stopping on the first non-zero exit.
 
-The process-spawning runner is the next integration slice.
+Production wiring can use the built-in process executor; tests should inject a
+deterministic executor. The next integration slice is converting runner command
+evidence into a validated `AgentResult` and PR artifact bundle.

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -31,3 +31,12 @@ Production wiring can use the built-in process executor; tests should inject a
 deterministic executor. Runner command evidence can be converted into a
 validated `AgentResult` and durable artifact bundle. Pull request creation is
 also planned and executed through the same command seam using `gh pr create`.
+
+`runSingleAgentRequest` wires the production-alpha happy path:
+
+1. Enqueue an `AgentRequest`.
+2. Claim it from the JSONL queue.
+3. Execute the Codex runner plan.
+4. Create a PR if the runner succeeds.
+5. Build and persist a validated `AgentResult` bundle.
+6. Complete the queue item with pass/fail evidence.

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -55,5 +55,16 @@ pnpm run autonomous-scheduler:cli -- status /tmp/factory-queue
 `run-single` and `daemon` are intentionally explicit because they execute `git`,
 `codex`, and `gh` against the requested repo.
 
+Use `--dry-run` to exercise the queue, runner, PR, result, and bundle paths
+without invoking external commands:
+
+```bash
+pnpm run autonomous-scheduler:cli -- run-single /tmp/factory-queue \
+  packages/autonomous-scheduler/fixtures/strategy-recipes-agent-request.json \
+  --repo-root /tmp/strategy-recipes \
+  --bundle-dir /tmp/factory-bundle \
+  --dry-run
+```
+
 Queue claims include leases and heartbeats. Expired claims can be reclaimed by a
 later runner; active claims are excluded from pending queue counts.

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -29,5 +29,5 @@ injectable executor:
 
 Production wiring can use the built-in process executor; tests should inject a
 deterministic executor. Runner command evidence can be converted into a
-validated `AgentResult` and durable artifact bundle. The next integration slice
-is wiring PR creation.
+validated `AgentResult` and durable artifact bundle. Pull request creation is
+also planned and executed through the same command seam using `gh pr create`.

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -51,3 +51,6 @@ pnpm run autonomous-scheduler:cli -- status /tmp/factory-queue
 
 `run-single` is intentionally explicit because it executes `git`, `codex`, and
 `gh` against the requested repo.
+
+Queue claims include leases and heartbeats. Expired claims can be reclaimed by a
+later runner; active claims are excluded from pending queue counts.

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -1,0 +1,28 @@
+# @factory/autonomous-scheduler
+
+Contracts for the Function Factory autonomous scheduler boundary.
+
+This package does not run Codex. It defines the fail-closed data shapes the
+Governor and queue use to request Codex work, receive evidence, and record queue
+events. It also includes a local JSONL queue reference implementation for
+production-alpha dogfooding. Runtime implementations consume these contracts
+from:
+
+1. WorkGraph node selected by the Governor.
+2. `AgentRequest` written to the queue.
+3. Codex runner claims the request and opens a PR branch.
+4. `AgentResult` returns test, diff, artifact, and PR evidence.
+5. Coverage and verifier components decide the next WorkGraph node.
+
+The initial operational posture is PR/branch mode. Direct default-branch
+mutation, production deploys, force-pushes, and secret edits are explicitly
+outside the permitted contract.
+
+The Codex runner adapter currently plans execution instead of spawning a process:
+
+1. Validate the `AgentRequest`.
+2. Derive the PR branch name.
+3. Produce git preflight commands.
+4. Build the Codex worker prompt with policy, context, commands, and evidence requirements.
+
+The process-spawning runner is the next integration slice.

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -28,5 +28,6 @@ injectable executor:
 5. Execute the plan sequentially, stopping on the first non-zero exit.
 
 Production wiring can use the built-in process executor; tests should inject a
-deterministic executor. The next integration slice is converting runner command
-evidence into a validated `AgentResult` and PR artifact bundle.
+deterministic executor. Runner command evidence can be converted into a
+validated `AgentResult`; the next integration slice is writing the artifact
+bundle contents to disk and wiring PR creation.

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -29,5 +29,5 @@ injectable executor:
 
 Production wiring can use the built-in process executor; tests should inject a
 deterministic executor. Runner command evidence can be converted into a
-validated `AgentResult`; the next integration slice is writing the artifact
-bundle contents to disk and wiring PR creation.
+validated `AgentResult` and durable artifact bundle. The next integration slice
+is wiring PR creation.

--- a/packages/autonomous-scheduler/fixtures/strategy-recipes-agent-request.json
+++ b/packages/autonomous-scheduler/fixtures/strategy-recipes-agent-request.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": "factory.agent-request.v0",
+  "id": "AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW",
+  "createdAt": "2026-04-30T14:00:00.000Z",
+  "workgraph": {
+    "id": "WG-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW",
+    "nodeId": "first-product-view",
+    "sourcePrdId": "PRD-STRATEGY-RECIPES-UX-V1-1",
+    "sourceRefs": [
+      "Strategy_Recipes_UX_Architecture_v1.1.md",
+      "ADR-0001-autonomous-scheduler-boundary.md"
+    ]
+  },
+  "role": "builder",
+  "objective": "Implement the first Strategy.Recipes product view as an external workload built by Function Factory.",
+  "prompt": "Build the first product view for Strategy.Recipes from the v1.1 UX architecture. Keep Strategy.Recipes separate from Function Factory. Produce a PR branch with docs, tests, and implementation evidence.",
+  "repo": {
+    "provider": "github",
+    "owner": "Wescome",
+    "name": "strategy-recipes",
+    "defaultBranch": "main",
+    "remoteUrl": "https://github.com/Wescome/strategy-recipes.git"
+  },
+  "branch": {
+    "mode": "new_pr_branch",
+    "base": "main",
+    "prefix": "factory/strategy-recipes-first-product-view"
+  },
+  "policy": {
+    "autonomyMode": "branch_pr",
+    "allowedPaths": [
+      "README.md",
+      "docs/**",
+      "packages/**",
+      "apps/**",
+      "examples/**",
+      "tests/**"
+    ],
+    "forbiddenActions": [
+      "merge_default_branch",
+      "deploy_production",
+      "force_push",
+      "delete_remote_branch",
+      "edit_secrets"
+    ],
+    "requiresHumanApprovalFor": [
+      "merge_default_branch",
+      "deploy_production",
+      "edit_secrets"
+    ],
+    "maxRuntimeMinutes": 90
+  },
+  "context": {
+    "summary": "Strategy.Recipes is a separate product/platform workload. Function Factory should schedule and verify the implementation rather than manually acting as the builder.",
+    "artifacts": [
+      {
+        "id": "STRATEGY-RECIPES-UX-V1-1",
+        "kind": "external-design",
+        "path": "/Users/wes/Downloads/Strategy_Recipes_UX_Architecture_v1.1.md"
+      }
+    ]
+  },
+  "acceptanceCriteria": [
+    "The product view renders the typed object graph, view registry, coherence report, and recipe panel concepts from Strategy.Recipes UX v1.1.",
+    "The implementation is isolated to the Strategy.Recipes repo and does not mutate Function Factory.",
+    "The PR includes tests or smoke evidence for the first product view.",
+    "The PR description links implementation evidence and any follow-up work."
+  ],
+  "requiredCommands": [
+    "pnpm install --frozen-lockfile",
+    "pnpm test",
+    "pnpm typecheck"
+  ],
+  "expectedArtifacts": [
+    {
+      "path": "docs/product/first-product-view.md",
+      "kind": "product-doc"
+    },
+    {
+      "path": "packages/strategy-objects/src/index.ts",
+      "kind": "implementation"
+    },
+    {
+      "path": "tests/first-product-view.test.ts",
+      "kind": "test"
+    }
+  ],
+  "evidenceRequired": [
+    "git_diff",
+    "test_output",
+    "typecheck_output",
+    "artifact_paths",
+    "pr_url"
+  ]
+}

--- a/packages/autonomous-scheduler/fixtures/strategy-recipes-agent-result.json
+++ b/packages/autonomous-scheduler/fixtures/strategy-recipes-agent-result.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "factory.agent-result.v0",
+  "id": "ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW",
+  "requestId": "AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW",
+  "agentRunId": "RUN-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-001",
+  "status": "completed",
+  "completedAt": "2026-04-30T15:00:00.000Z",
+  "branchName": "factory/strategy-recipes-first-product-view",
+  "prUrl": "https://github.com/Wescome/strategy-recipes/pull/1",
+  "summary": "Implemented the first Strategy.Recipes product view and attached evidence.",
+  "changedFiles": [
+    "docs/product/first-product-view.md",
+    "packages/strategy-objects/src/index.ts",
+    "tests/first-product-view.test.ts"
+  ],
+  "commands": [
+    {
+      "command": "pnpm test",
+      "exitCode": 0,
+      "outputRef": "artifacts/test-output.txt"
+    },
+    {
+      "command": "pnpm typecheck",
+      "exitCode": 0,
+      "outputRef": "artifacts/typecheck-output.txt"
+    }
+  ],
+  "evidence": [
+    {
+      "kind": "git_diff",
+      "path": "artifacts/diff.patch",
+      "summary": "Patch for the Strategy.Recipes first product view."
+    },
+    {
+      "kind": "test_output",
+      "path": "artifacts/test-output.txt",
+      "summary": "Test output captured from the worker run."
+    },
+    {
+      "kind": "typecheck_output",
+      "path": "artifacts/typecheck-output.txt",
+      "summary": "Typecheck output captured from the worker run."
+    },
+    {
+      "kind": "pr_url",
+      "url": "https://github.com/Wescome/strategy-recipes/pull/1",
+      "summary": "PR opened by the Codex runner."
+    }
+  ]
+}

--- a/packages/autonomous-scheduler/package.json
+++ b/packages/autonomous-scheduler/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@factory/autonomous-scheduler",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "lint": "echo 'lint: TODO'"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.4.0"
+  }
+}

--- a/packages/autonomous-scheduler/src/cli.ts
+++ b/packages/autonomous-scheduler/src/cli.ts
@@ -41,12 +41,28 @@ async function main(): Promise<void> {
     }
 
     if (command === 'claim') {
-      const queue = new JsonlAgentQueue({
+      const queueOptions: ConstructorParameters<typeof JsonlAgentQueue>[0] = {
         queueDir: requiredArg(args, 0, 'queue dir'),
         actor: option(args, '--actor') ?? 'factory-runner',
-      })
+      }
+      const leaseMs = numberOption(args, '--lease-ms')
+      if (leaseMs !== undefined) queueOptions.leaseMs = leaseMs
+      const queue = new JsonlAgentQueue(queueOptions)
       const request = await queue.claimNext()
       printJson({ ok: true, claimed: request?.id ?? null })
+      return
+    }
+
+    if (command === 'heartbeat') {
+      const queueOptions: ConstructorParameters<typeof JsonlAgentQueue>[0] = {
+        queueDir: requiredArg(args, 0, 'queue dir'),
+        actor: option(args, '--actor') ?? 'factory-runner',
+      }
+      const leaseMs = numberOption(args, '--lease-ms')
+      if (leaseMs !== undefined) queueOptions.leaseMs = leaseMs
+      const queue = new JsonlAgentQueue(queueOptions)
+      const claim = await queue.heartbeat(requiredArg(args, 1, 'request id'))
+      printJson({ ok: true, claim })
       return
     }
 
@@ -132,7 +148,8 @@ function printHelp(): void {
     'Commands:',
     '  validate-request <request.json>',
     '  enqueue <queue-dir> <request.json> [--actor name]',
-    '  claim <queue-dir> [--actor name]',
+    '  claim <queue-dir> [--actor name] [--lease-ms n]',
+    '  heartbeat <queue-dir> <request-id> [--actor name] [--lease-ms n]',
     '  status <queue-dir> [--actor name]',
     '  plan <request.json> --repo-root <path>',
     '  run-single <queue-dir> <request.json> --repo-root <path> --bundle-dir <path> [--changed-files a,b] [--diff-file path]',
@@ -175,6 +192,16 @@ function csvOption(args: string[], name: string): string[] | undefined {
   const value = option(args, name)
   if (!value) return undefined
   return value.split(',').map((entry) => entry.trim()).filter(Boolean)
+}
+
+function numberOption(args: string[], name: string): number | undefined {
+  const value = option(args, name)
+  if (!value) return undefined
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number`)
+  }
+  return parsed
 }
 
 function printJson(value: unknown): void {

--- a/packages/autonomous-scheduler/src/cli.ts
+++ b/packages/autonomous-scheduler/src/cli.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises'
 import {
   JsonlAgentQueue,
   planCodexRunner,
+  runQueueDaemon,
   runSingleAgentRequest,
   validateAgentRequest,
 } from './index.js'
@@ -131,6 +132,25 @@ async function main(): Promise<void> {
       return
     }
 
+    if (command === 'daemon') {
+      const queueDir = requiredArg(args, 0, 'queue dir')
+      const repoRoot = requiredOption(args, '--repo-root')
+      const bundleRoot = requiredOption(args, '--bundle-root')
+      const daemonOptions: Parameters<typeof runQueueDaemon>[0] = {
+        queue: new JsonlAgentQueue({ queueDir, actor: option(args, '--actor') ?? 'factory-daemon' }),
+        repoRoot,
+        bundleRoot,
+        pollIntervalMs: numberOption(args, '--poll-ms') ?? 5_000,
+      }
+      const maxIterations = numberOption(args, '--max-iterations')
+      if (maxIterations !== undefined) daemonOptions.maxIterations = maxIterations
+
+      const outcome = await runQueueDaemon(daemonOptions)
+
+      printJson({ ok: true, outcome })
+      return
+    }
+
     throw new Error(`Unknown command: ${command}`)
   } catch (error) {
     process.exitCode = 1
@@ -153,8 +173,9 @@ function printHelp(): void {
     '  status <queue-dir> [--actor name]',
     '  plan <request.json> --repo-root <path>',
     '  run-single <queue-dir> <request.json> --repo-root <path> --bundle-dir <path> [--changed-files a,b] [--diff-file path]',
+    '  daemon <queue-dir> --repo-root <path> --bundle-root <path> [--poll-ms n] [--max-iterations n]',
     '',
-    'run-single executes git, codex, and gh commands through the production process executor.',
+    'run-single and daemon execute git, codex, and gh commands through the production process executor.',
   ].join('\n'))
 }
 

--- a/packages/autonomous-scheduler/src/cli.ts
+++ b/packages/autonomous-scheduler/src/cli.ts
@@ -2,6 +2,7 @@
 import { readFile } from 'node:fs/promises'
 import {
   JsonlAgentQueue,
+  createDryRunCommandExecutor,
   planCodexRunner,
   runQueueDaemon,
   runSingleAgentRequest,
@@ -108,6 +109,9 @@ async function main(): Promise<void> {
       const changedFiles = csvOption(args, '--changed-files')
       const diffFile = option(args, '--diff-file')
       const diff = diffFile ? await readFile(diffFile, 'utf8') : undefined
+      const dryRunExecutor = hasFlag(args, '--dry-run')
+        ? createDryRunExecutorFromArgs(args)
+        : undefined
 
       const runOptions: Parameters<typeof runSingleAgentRequest>[1] = {
         queue: new JsonlAgentQueue({ queueDir, actor: option(args, '--actor') ?? 'factory-governor' }),
@@ -119,6 +123,10 @@ async function main(): Promise<void> {
       }
       if (changedFiles) runOptions.changedFiles = changedFiles
       if (diff !== undefined) runOptions.diff = diff
+      if (dryRunExecutor) {
+        runOptions.codexExecutor = dryRunExecutor
+        runOptions.pullRequestExecutor = dryRunExecutor
+      }
 
       const outcome = await runSingleAgentRequest(request, runOptions)
 
@@ -144,6 +152,13 @@ async function main(): Promise<void> {
       }
       const maxIterations = numberOption(args, '--max-iterations')
       if (maxIterations !== undefined) daemonOptions.maxIterations = maxIterations
+      const dryRunExecutor = hasFlag(args, '--dry-run')
+        ? createDryRunExecutorFromArgs(args)
+        : undefined
+      if (dryRunExecutor) {
+        daemonOptions.codexExecutor = dryRunExecutor
+        daemonOptions.pullRequestExecutor = dryRunExecutor
+      }
 
       const outcome = await runQueueDaemon(daemonOptions)
 
@@ -172,10 +187,10 @@ function printHelp(): void {
     '  heartbeat <queue-dir> <request-id> [--actor name] [--lease-ms n]',
     '  status <queue-dir> [--actor name]',
     '  plan <request.json> --repo-root <path>',
-    '  run-single <queue-dir> <request.json> --repo-root <path> --bundle-dir <path> [--changed-files a,b] [--diff-file path]',
-    '  daemon <queue-dir> --repo-root <path> --bundle-root <path> [--poll-ms n] [--max-iterations n]',
+    '  run-single <queue-dir> <request.json> --repo-root <path> --bundle-dir <path> [--changed-files a,b] [--diff-file path] [--dry-run]',
+    '  daemon <queue-dir> --repo-root <path> --bundle-root <path> [--poll-ms n] [--max-iterations n] [--dry-run]',
     '',
-    'run-single and daemon execute git, codex, and gh commands through the production process executor.',
+    'run-single and daemon execute git, codex, and gh commands unless --dry-run is supplied.',
   ].join('\n'))
 }
 
@@ -223,6 +238,17 @@ function numberOption(args: string[], name: string): number | undefined {
     throw new Error(`${name} must be a positive number`)
   }
   return parsed
+}
+
+function hasFlag(args: string[], name: string): boolean {
+  return args.includes(name)
+}
+
+function createDryRunExecutorFromArgs(args: string[]): ReturnType<typeof createDryRunCommandExecutor> {
+  const options: Parameters<typeof createDryRunCommandExecutor>[0] = {}
+  const prUrl = option(args, '--mock-pr-url')
+  if (prUrl) options.prUrl = prUrl
+  return createDryRunCommandExecutor(options)
 }
 
 function printJson(value: unknown): void {

--- a/packages/autonomous-scheduler/src/cli.ts
+++ b/packages/autonomous-scheduler/src/cli.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises'
+import {
+  JsonlAgentQueue,
+  planCodexRunner,
+  runSingleAgentRequest,
+  validateAgentRequest,
+} from './index.js'
+
+async function main(): Promise<void> {
+  const rawArgs = process.argv.slice(2)
+  const cliArgs = rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs
+  const [command, ...args] = cliArgs
+
+  try {
+    if (!command || command === 'help' || command === '--help') {
+      printHelp()
+      return
+    }
+
+    if (command === 'validate-request') {
+      const request = validateAgentRequest(await readJson(requiredArg(args, 0, 'request file')))
+      printJson({
+        ok: true,
+        id: request.id,
+        role: request.role,
+        repo: request.repo,
+        workgraph: request.workgraph,
+      })
+      return
+    }
+
+    if (command === 'enqueue') {
+      const queue = new JsonlAgentQueue({
+        queueDir: requiredArg(args, 0, 'queue dir'),
+        actor: option(args, '--actor') ?? 'factory-governor',
+      })
+      const request = await queue.enqueue(await readJson(requiredArg(args, 1, 'request file')))
+      printJson({ ok: true, enqueued: request.id, status: await queue.status() })
+      return
+    }
+
+    if (command === 'claim') {
+      const queue = new JsonlAgentQueue({
+        queueDir: requiredArg(args, 0, 'queue dir'),
+        actor: option(args, '--actor') ?? 'factory-runner',
+      })
+      const request = await queue.claimNext()
+      printJson({ ok: true, claimed: request?.id ?? null })
+      return
+    }
+
+    if (command === 'status') {
+      const queue = new JsonlAgentQueue({
+        queueDir: requiredArg(args, 0, 'queue dir'),
+        actor: option(args, '--actor') ?? 'factory-governor',
+      })
+      printJson({ ok: true, status: await queue.status(), events: await queue.listEvents() })
+      return
+    }
+
+    if (command === 'plan') {
+      const request = await readJson(requiredArg(args, 0, 'request file'))
+      const repoRoot = requiredOption(args, '--repo-root')
+      const plan = planCodexRunner(request, { repoRoot })
+      printJson({
+        ok: true,
+        requestId: plan.requestId,
+        branchName: plan.branchName,
+        preflightCommands: plan.preflightCommands,
+        codexCommand: {
+          command: plan.codexCommand.command,
+          args: [plan.codexCommand.args[0], '<prompt omitted>'],
+          cwd: plan.codexCommand.cwd,
+        },
+        prompt: plan.prompt,
+      })
+      return
+    }
+
+    if (command === 'run-single') {
+      const queueDir = requiredArg(args, 0, 'queue dir')
+      const requestPath = requiredArg(args, 1, 'request file')
+      const request = validateAgentRequest(await readJson(requestPath))
+      const repoRoot = requiredOption(args, '--repo-root')
+      const bundleDir = requiredOption(args, '--bundle-dir')
+      const now = new Date().toISOString()
+      const stamp = now.replace(/[^0-9TZ]/g, '')
+      const resultId = option(args, '--result-id') ?? `ARES-${request.id.slice(3)}-${stamp}`
+      const agentRunId = option(args, '--agent-run-id') ?? `RUN-${request.id.slice(3)}-${stamp}`
+      const changedFiles = csvOption(args, '--changed-files')
+      const diffFile = option(args, '--diff-file')
+      const diff = diffFile ? await readFile(diffFile, 'utf8') : undefined
+
+      const runOptions: Parameters<typeof runSingleAgentRequest>[1] = {
+        queue: new JsonlAgentQueue({ queueDir, actor: option(args, '--actor') ?? 'factory-governor' }),
+        repoRoot,
+        bundleDir,
+        resultId,
+        agentRunId,
+        completedAt: now,
+      }
+      if (changedFiles) runOptions.changedFiles = changedFiles
+      if (diff !== undefined) runOptions.diff = diff
+
+      const outcome = await runSingleAgentRequest(request, runOptions)
+
+      printJson({
+        ok: true,
+        requestId: outcome.request.id,
+        status: outcome.result.status,
+        prUrl: outcome.result.prUrl ?? null,
+        bundle: outcome.bundle,
+      })
+      return
+    }
+
+    throw new Error(`Unknown command: ${command}`)
+  } catch (error) {
+    process.exitCode = 1
+    printJson({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+function printHelp(): void {
+  console.log([
+    'factory autonomous scheduler CLI',
+    '',
+    'Commands:',
+    '  validate-request <request.json>',
+    '  enqueue <queue-dir> <request.json> [--actor name]',
+    '  claim <queue-dir> [--actor name]',
+    '  status <queue-dir> [--actor name]',
+    '  plan <request.json> --repo-root <path>',
+    '  run-single <queue-dir> <request.json> --repo-root <path> --bundle-dir <path> [--changed-files a,b] [--diff-file path]',
+    '',
+    'run-single executes git, codex, and gh commands through the production process executor.',
+  ].join('\n'))
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, 'utf8')) as unknown
+}
+
+function requiredArg(args: string[], index: number, label: string): string {
+  const value = args[index]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing ${label}`)
+  }
+  return value
+}
+
+function option(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name)
+  if (index === -1) return undefined
+  const value = args[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing value for ${name}`)
+  }
+  return value
+}
+
+function requiredOption(args: string[], name: string): string {
+  const value = option(args, name)
+  if (!value) {
+    throw new Error(`Missing ${name}`)
+  }
+  return value
+}
+
+function csvOption(args: string[], name: string): string[] | undefined {
+  const value = option(args, name)
+  if (!value) return undefined
+  return value.split(',').map((entry) => entry.trim()).filter(Boolean)
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2))
+}
+
+await main()

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process'
 import { appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
@@ -203,6 +204,31 @@ export interface CodexRunnerPlan {
   preflightCommands: RunnerCommand[]
   codexCommand: RunnerCommand
   prompt: string
+}
+
+export interface CommandRunResult {
+  command: string
+  args: string[]
+  cwd: string
+  exitCode: number
+  stdout: string
+  stderr: string
+  startedAt: string
+  completedAt: string
+}
+
+export interface CodexRunnerExecution {
+  requestId: string
+  branchName: string
+  status: 'completed' | 'failed'
+  commands: CommandRunResult[]
+  failedCommand?: string
+}
+
+export type CommandExecutor = (command: RunnerCommand) => Promise<CommandRunResult>
+
+export interface ProcessCommandExecutorOptions {
+  now?: () => Date
 }
 
 export class AutonomousSchedulerValidationError extends Error {
@@ -443,6 +469,56 @@ export function buildCodexWorkerPrompt(input: unknown): string {
     'Return an AgentResult-compatible summary with changed files, command evidence, PR URL, and refusalReason if refused.',
     'Do not merge, deploy, force-push, delete remote branches, edit secrets, or write outside allowed paths.',
   ].join('\n')
+}
+
+export async function executeCodexRunnerPlan(
+  plan: CodexRunnerPlan,
+  executor: CommandExecutor = createProcessCommandExecutor(),
+): Promise<CodexRunnerExecution> {
+  const commands: CommandRunResult[] = []
+
+  for (const command of [...plan.preflightCommands, plan.codexCommand]) {
+    const result = await executor(command)
+    commands.push(result)
+
+    if (result.exitCode !== 0) {
+      return {
+        requestId: plan.requestId,
+        branchName: plan.branchName,
+        status: 'failed',
+        commands,
+        failedCommand: stringifyCommand(command),
+      }
+    }
+  }
+
+  return {
+    requestId: plan.requestId,
+    branchName: plan.branchName,
+    status: 'completed',
+    commands,
+  }
+}
+
+export function createProcessCommandExecutor(options?: ProcessCommandExecutorOptions): CommandExecutor {
+  const now = options?.now ?? (() => new Date())
+
+  return async (command: RunnerCommand): Promise<CommandRunResult> => {
+    const startedAt = now().toISOString()
+    const { exitCode, stdout, stderr } = await spawnCommand(command)
+    const completedAt = now().toISOString()
+
+    return {
+      command: command.command,
+      args: command.args,
+      cwd: command.cwd,
+      exitCode,
+      stdout,
+      stderr,
+      startedAt,
+      completedAt,
+    }
+  }
 }
 
 export class JsonlAgentQueue {
@@ -954,6 +1030,36 @@ function sanitizeId(id: string): string {
 
 function buildBranchName(request: AgentRequest): string {
   return `${request.branch.prefix}/${sanitizeId(request.id).toLowerCase()}`
+}
+
+function stringifyCommand(command: RunnerCommand): string {
+  return [command.command, ...command.args].join(' ')
+}
+
+async function spawnCommand(command: RunnerCommand): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command.command, command.args, {
+      cwd: command.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout.push(chunk)
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr.push(chunk)
+    })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      resolve({
+        exitCode: code ?? 1,
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: Buffer.concat(stderr).toString('utf8'),
+      })
+    })
+  })
 }
 
 function isNotFound(error: unknown): boolean {

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -1,0 +1,965 @@
+import { appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const AGENT_REQUEST_SCHEMA_VERSION = 'factory.agent-request.v0' as const
+export const AGENT_RESULT_SCHEMA_VERSION = 'factory.agent-result.v0' as const
+export const QUEUE_EVENT_SCHEMA_VERSION = 'factory.queue-event.v0' as const
+
+export const AGENT_ROLES = [
+  'architect',
+  'builder',
+  'tester',
+  'critic',
+  'verifier',
+  'operator',
+] as const
+
+export const AUTONOMY_MODES = [
+  'recommend_only',
+  'enqueue_only',
+  'branch_pr',
+  'multi_agent_pr',
+] as const
+
+export const BRANCH_MODES = ['read_only', 'new_pr_branch'] as const
+
+export const FORBIDDEN_ACTIONS = [
+  'merge_default_branch',
+  'deploy_production',
+  'force_push',
+  'delete_remote_branch',
+  'edit_secrets',
+] as const
+
+export const EVIDENCE_KINDS = [
+  'git_diff',
+  'test_output',
+  'typecheck_output',
+  'artifact_paths',
+  'pr_url',
+  'review_report',
+  'coverage_report',
+] as const
+
+export const QUEUE_EVENT_TYPES = [
+  'request.enqueued',
+  'request.claimed',
+  'request.heartbeat',
+  'request.completed',
+  'request.failed',
+  'request.dead_lettered',
+] as const
+
+export type AgentRole = (typeof AGENT_ROLES)[number]
+export type AutonomyMode = (typeof AUTONOMY_MODES)[number]
+export type BranchMode = (typeof BRANCH_MODES)[number]
+export type ForbiddenAction = (typeof FORBIDDEN_ACTIONS)[number]
+export type EvidenceKind = (typeof EVIDENCE_KINDS)[number]
+export type QueueEventType = (typeof QUEUE_EVENT_TYPES)[number]
+type NonEmptyReadonlyArray<T> = readonly [T, ...T[]]
+
+export interface WorkGraphHandle {
+  id: string
+  nodeId: string
+  sourcePrdId?: string
+  sourceRefs: string[]
+}
+
+export interface RepoTarget {
+  provider: 'github' | 'local'
+  owner?: string
+  name: string
+  defaultBranch: string
+  remoteUrl?: string
+  localPath?: string
+}
+
+export interface BranchPolicy {
+  mode: BranchMode
+  base: string
+  prefix: string
+}
+
+export interface ExecutionPolicy {
+  autonomyMode: AutonomyMode
+  allowedPaths: string[]
+  forbiddenActions: ForbiddenAction[]
+  requiresHumanApprovalFor: ForbiddenAction[]
+  maxRuntimeMinutes?: number
+}
+
+export interface ContextArtifact {
+  id: string
+  kind: string
+  path: string
+}
+
+export interface RequestContext {
+  summary: string
+  artifacts: ContextArtifact[]
+}
+
+export interface ExpectedArtifact {
+  path: string
+  kind: string
+}
+
+export interface AgentRequest {
+  schemaVersion: typeof AGENT_REQUEST_SCHEMA_VERSION
+  id: string
+  createdAt: string
+  workgraph: WorkGraphHandle
+  role: AgentRole
+  objective: string
+  prompt: string
+  repo: RepoTarget
+  branch: BranchPolicy
+  policy: ExecutionPolicy
+  context: RequestContext
+  acceptanceCriteria: string[]
+  requiredCommands: string[]
+  expectedArtifacts: ExpectedArtifact[]
+  evidenceRequired: EvidenceKind[]
+}
+
+export type AgentResultStatus = 'completed' | 'failed' | 'refused'
+
+export interface CommandEvidence {
+  command: string
+  exitCode: number
+  outputRef: string
+}
+
+export interface EvidenceRef {
+  kind: EvidenceKind
+  path?: string
+  url?: string
+  summary: string
+}
+
+export interface AgentResult {
+  schemaVersion: typeof AGENT_RESULT_SCHEMA_VERSION
+  id: string
+  requestId: string
+  agentRunId: string
+  status: AgentResultStatus
+  completedAt: string
+  branchName?: string
+  prUrl?: string
+  summary: string
+  changedFiles: string[]
+  commands: CommandEvidence[]
+  evidence: EvidenceRef[]
+  refusalReason?: string
+}
+
+export interface QueueEvent {
+  schemaVersion: typeof QUEUE_EVENT_SCHEMA_VERSION
+  id: string
+  type: QueueEventType
+  requestId: string
+  timestamp: string
+  actor: string
+  details: Record<string, unknown>
+}
+
+export interface JsonlAgentQueueOptions {
+  queueDir: string
+  actor: string
+  now?: () => Date
+}
+
+export interface QueueClaim {
+  requestId: string
+  actor: string
+  claimedAt: string
+}
+
+export interface JsonlQueueStatus {
+  queueDir: string
+  total: number
+  pending: number
+  claimed: number
+  completed: number
+  failed: number
+  refused: number
+}
+
+export interface RunnerCommand {
+  command: string
+  args: string[]
+  cwd: string
+}
+
+export interface CodexRunnerPlanOptions {
+  repoRoot: string
+  codexBinary?: string
+}
+
+export interface CodexRunnerPlan {
+  requestId: string
+  branchName: string
+  repoRoot: string
+  preflightCommands: RunnerCommand[]
+  codexCommand: RunnerCommand
+  prompt: string
+}
+
+export class AutonomousSchedulerValidationError extends Error {
+  public readonly issues: string[]
+
+  public constructor(message: string, issues: string[]) {
+    super(message)
+    this.name = 'AutonomousSchedulerValidationError'
+    this.issues = issues
+  }
+}
+
+export function validateAgentRequest(input: unknown): AgentRequest {
+  const issues: string[] = []
+  const data = record(input, 'AgentRequest', issues)
+
+  const schemaVersion = literal(
+    value(data, 'schemaVersion'),
+    AGENT_REQUEST_SCHEMA_VERSION,
+    'schemaVersion',
+    issues,
+  )
+  const id = prefixedString(value(data, 'id'), 'AR-', 'id', issues)
+  const createdAt = isoString(value(data, 'createdAt'), 'createdAt', issues)
+  const workgraph = parseWorkGraph(record(value(data, 'workgraph'), 'workgraph', issues), issues)
+  const role = oneOf(value(data, 'role'), AGENT_ROLES, 'role', issues)
+  const objective = nonEmptyString(value(data, 'objective'), 'objective', issues)
+  const prompt = nonEmptyString(value(data, 'prompt'), 'prompt', issues)
+  const repo = parseRepo(record(value(data, 'repo'), 'repo', issues), issues)
+  const branch = parseBranch(record(value(data, 'branch'), 'branch', issues), issues)
+  const policy = parsePolicy(record(value(data, 'policy'), 'policy', issues), issues)
+  const context = parseContext(record(value(data, 'context'), 'context', issues), issues)
+  const acceptanceCriteria = nonEmptyStringArray(value(data, 'acceptanceCriteria'), 'acceptanceCriteria', issues)
+  const requiredCommands = nonEmptyStringArray(value(data, 'requiredCommands'), 'requiredCommands', issues)
+  const expectedArtifacts = parseExpectedArtifacts(array(value(data, 'expectedArtifacts'), 'expectedArtifacts', issues), issues)
+  const evidenceRequired = enumArray(value(data, 'evidenceRequired'), EVIDENCE_KINDS, 'evidenceRequired', issues)
+
+  if (evidenceRequired.length === 0) {
+    issues.push('evidenceRequired must contain at least one evidence kind')
+  }
+
+  if (role === 'builder' && branch.mode !== 'new_pr_branch') {
+    issues.push('builder requests must use branch.mode=new_pr_branch')
+  }
+
+  throwIfIssues('AgentRequest validation failed', issues)
+
+  return {
+    schemaVersion,
+    id,
+    createdAt,
+    workgraph,
+    role,
+    objective,
+    prompt,
+    repo,
+    branch,
+    policy,
+    context,
+    acceptanceCriteria,
+    requiredCommands,
+    expectedArtifacts,
+    evidenceRequired,
+  }
+}
+
+export function validateAgentResult(input: unknown): AgentResult {
+  const issues: string[] = []
+  const data = record(input, 'AgentResult', issues)
+
+  const schemaVersion = literal(
+    value(data, 'schemaVersion'),
+    AGENT_RESULT_SCHEMA_VERSION,
+    'schemaVersion',
+    issues,
+  )
+  const id = prefixedString(value(data, 'id'), 'ARES-', 'id', issues)
+  const requestId = prefixedString(value(data, 'requestId'), 'AR-', 'requestId', issues)
+  const agentRunId = prefixedString(value(data, 'agentRunId'), 'RUN-', 'agentRunId', issues)
+  const status = oneOf(value(data, 'status'), ['completed', 'failed', 'refused'] as const, 'status', issues)
+  const completedAt = isoString(value(data, 'completedAt'), 'completedAt', issues)
+  const branchName = optionalNonEmptyString(value(data, 'branchName'), 'branchName', issues)
+  const prUrl = optionalNonEmptyString(value(data, 'prUrl'), 'prUrl', issues)
+  const summary = nonEmptyString(value(data, 'summary'), 'summary', issues)
+  const changedFiles = stringArray(value(data, 'changedFiles'), 'changedFiles', issues)
+  const commands = parseCommands(array(value(data, 'commands'), 'commands', issues), issues)
+  const evidence = parseEvidence(array(value(data, 'evidence'), 'evidence', issues), issues)
+  const refusalReason = optionalNonEmptyString(value(data, 'refusalReason'), 'refusalReason', issues)
+
+  if (status === 'completed') {
+    if (!branchName) issues.push('completed AgentResult must include branchName')
+    if (!prUrl) issues.push('completed AgentResult must include prUrl')
+    if (changedFiles.length === 0) issues.push('completed AgentResult must include changedFiles')
+    if (!evidence.some((entry) => entry.kind === 'pr_url')) {
+      issues.push('completed AgentResult must include pr_url evidence')
+    }
+  }
+
+  if (status === 'refused' && !refusalReason) {
+    issues.push('refused AgentResult must include refusalReason')
+  }
+
+  throwIfIssues('AgentResult validation failed', issues)
+
+  const result: AgentResult = {
+    schemaVersion,
+    id,
+    requestId,
+    agentRunId,
+    status,
+    completedAt,
+    summary,
+    changedFiles,
+    commands,
+    evidence,
+  }
+
+  if (branchName) result.branchName = branchName
+  if (prUrl) result.prUrl = prUrl
+  if (refusalReason) result.refusalReason = refusalReason
+
+  return result
+}
+
+export function validateQueueEvent(input: unknown): QueueEvent {
+  const issues: string[] = []
+  const data = record(input, 'QueueEvent', issues)
+
+  const schemaVersion = literal(
+    value(data, 'schemaVersion'),
+    QUEUE_EVENT_SCHEMA_VERSION,
+    'schemaVersion',
+    issues,
+  )
+  const id = prefixedString(value(data, 'id'), 'QE-', 'id', issues)
+  const type = oneOf(value(data, 'type'), QUEUE_EVENT_TYPES, 'type', issues)
+  const requestId = prefixedString(value(data, 'requestId'), 'AR-', 'requestId', issues)
+  const timestamp = isoString(value(data, 'timestamp'), 'timestamp', issues)
+  const actor = nonEmptyString(value(data, 'actor'), 'actor', issues)
+  const details = record(value(data, 'details'), 'details', issues)
+
+  throwIfIssues('QueueEvent validation failed', issues)
+
+  return {
+    schemaVersion,
+    id,
+    type,
+    requestId,
+    timestamp,
+    actor,
+    details,
+  }
+}
+
+export function planCodexRunner(input: unknown, options: CodexRunnerPlanOptions): CodexRunnerPlan {
+  const request = validateAgentRequest(input)
+
+  if (request.branch.mode !== 'new_pr_branch') {
+    throw new Error(`Codex runner requires branch.mode=new_pr_branch for ${request.id}`)
+  }
+
+  if (request.policy.autonomyMode !== 'branch_pr' && request.policy.autonomyMode !== 'multi_agent_pr') {
+    throw new Error(`Codex runner cannot execute autonomyMode=${request.policy.autonomyMode}`)
+  }
+
+  const branchName = buildBranchName(request)
+  const codexBinary = options.codexBinary ?? 'codex'
+  const prompt = buildCodexWorkerPrompt(request)
+
+  return {
+    requestId: request.id,
+    branchName,
+    repoRoot: options.repoRoot,
+    preflightCommands: [
+      {
+        command: 'git',
+        args: ['fetch', 'origin', request.branch.base],
+        cwd: options.repoRoot,
+      },
+      {
+        command: 'git',
+        args: ['switch', '-c', branchName, `origin/${request.branch.base}`],
+        cwd: options.repoRoot,
+      },
+      {
+        command: 'git',
+        args: ['status', '--short'],
+        cwd: options.repoRoot,
+      },
+    ],
+    codexCommand: {
+      command: codexBinary,
+      args: ['exec', prompt],
+      cwd: options.repoRoot,
+    },
+    prompt,
+  }
+}
+
+export function buildCodexWorkerPrompt(input: unknown): string {
+  const request = validateAgentRequest(input)
+
+  return [
+    'You are a Function Factory Codex worker.',
+    '',
+    `Request: ${request.id}`,
+    `Role: ${request.role}`,
+    `Objective: ${request.objective}`,
+    `WorkGraph: ${request.workgraph.id} / ${request.workgraph.nodeId}`,
+    `Repository: ${request.repo.provider}:${request.repo.owner ? `${request.repo.owner}/` : ''}${request.repo.name}`,
+    '',
+    'Execution policy:',
+    `- Autonomy mode: ${request.policy.autonomyMode}`,
+    `- Branch mode: ${request.branch.mode}`,
+    `- Base branch: ${request.branch.base}`,
+    `- Allowed paths: ${request.policy.allowedPaths.join(', ')}`,
+    `- Forbidden actions: ${request.policy.forbiddenActions.join(', ')}`,
+    `- Human approval required for: ${request.policy.requiresHumanApprovalFor.join(', ')}`,
+    '',
+    'Context artifacts:',
+    ...request.context.artifacts.map((artifact) => `- ${artifact.id} (${artifact.kind}): ${artifact.path}`),
+    '',
+    'Worker prompt:',
+    request.prompt,
+    '',
+    'Acceptance criteria:',
+    ...request.acceptanceCriteria.map((criterion, index) => `${index + 1}. ${criterion}`),
+    '',
+    'Required commands:',
+    ...request.requiredCommands.map((command) => `- ${command}`),
+    '',
+    'Expected artifacts:',
+    ...request.expectedArtifacts.map((artifact) => `- ${artifact.path} (${artifact.kind})`),
+    '',
+    'Required evidence:',
+    ...request.evidenceRequired.map((kind) => `- ${kind}`),
+    '',
+    'Return an AgentResult-compatible summary with changed files, command evidence, PR URL, and refusalReason if refused.',
+    'Do not merge, deploy, force-push, delete remote branches, edit secrets, or write outside allowed paths.',
+  ].join('\n')
+}
+
+export class JsonlAgentQueue {
+  private readonly queueDir: string
+  private readonly actor: string
+  private readonly now: () => Date
+
+  public constructor(options: JsonlAgentQueueOptions) {
+    this.queueDir = options.queueDir
+    this.actor = options.actor
+    this.now = options.now ?? (() => new Date())
+  }
+
+  public async init(): Promise<void> {
+    await mkdir(this.queueDir, { recursive: true })
+    await mkdir(this.claimsDir, { recursive: true })
+    await mkdir(this.resultsDir, { recursive: true })
+  }
+
+  public async enqueue(input: unknown): Promise<AgentRequest> {
+    await this.init()
+    const request = validateAgentRequest(input)
+    const existing = await this.listRequests()
+    if (existing.some((entry) => entry.id === request.id)) {
+      throw new Error(`AgentRequest already exists in queue: ${request.id}`)
+    }
+
+    await appendJsonLine(this.requestsPath, request)
+    await this.appendEvent('request.enqueued', request.id, {
+      role: request.role,
+      repo: request.repo.name,
+      workgraph: request.workgraph.id,
+    })
+
+    return request
+  }
+
+  public async listRequests(): Promise<AgentRequest[]> {
+    await this.init()
+    const entries = await readJsonLines(this.requestsPath)
+    return entries.map((entry) => validateAgentRequest(entry))
+  }
+
+  public async listEvents(): Promise<QueueEvent[]> {
+    await this.init()
+    const entries = await readJsonLines(this.eventsPath)
+    return entries.map((entry) => validateQueueEvent(entry))
+  }
+
+  public async claimNext(): Promise<AgentRequest | null> {
+    await this.init()
+    const requests = await this.listRequests()
+    const completed = new Set((await this.listResults()).map((result) => result.requestId))
+
+    for (const request of requests) {
+      if (completed.has(request.id)) continue
+
+      const claimPath = this.claimPath(request.id)
+      const claim: QueueClaim = {
+        requestId: request.id,
+        actor: this.actor,
+        claimedAt: this.now().toISOString(),
+      }
+
+      try {
+        await writeFile(claimPath, `${JSON.stringify(claim, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' })
+        await this.appendEvent('request.claimed', request.id, {
+          actor: this.actor,
+          claimPath,
+        })
+        return request
+      } catch (error) {
+        if (isAlreadyExists(error)) continue
+        throw error
+      }
+    }
+
+    return null
+  }
+
+  public async complete(input: unknown): Promise<AgentResult> {
+    await this.init()
+    const result = validateAgentResult(input)
+    const resultPath = this.resultPath(result.requestId)
+
+    try {
+      await writeFile(resultPath, `${JSON.stringify(result, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' })
+    } catch (error) {
+      if (isAlreadyExists(error)) {
+        throw new Error(`AgentResult already exists for request: ${result.requestId}`)
+      }
+      throw error
+    }
+
+    await this.appendEvent(result.status === 'completed' ? 'request.completed' : 'request.failed', result.requestId, {
+      status: result.status,
+      resultId: result.id,
+      prUrl: result.prUrl ?? null,
+    })
+
+    return result
+  }
+
+  public async status(): Promise<JsonlQueueStatus> {
+    await this.init()
+    const requests = await this.listRequests()
+    const claims = await this.listClaims()
+    const results = await this.listResults()
+    const resultRequestIds = new Set(results.map((result) => result.requestId))
+    const claimedRequestIds = new Set(claims.map((claim) => claim.requestId))
+    const completed = results.filter((result) => result.status === 'completed').length
+    const failed = results.filter((result) => result.status === 'failed').length
+    const refused = results.filter((result) => result.status === 'refused').length
+    const claimed = requests.filter((request) => claimedRequestIds.has(request.id) && !resultRequestIds.has(request.id)).length
+    const pending = requests.filter((request) => !claimedRequestIds.has(request.id) && !resultRequestIds.has(request.id)).length
+
+    return {
+      queueDir: this.queueDir,
+      total: requests.length,
+      pending,
+      claimed,
+      completed,
+      failed,
+      refused,
+    }
+  }
+
+  private async listClaims(): Promise<QueueClaim[]> {
+    const names = await readDirectoryOrEmpty(this.claimsDir)
+    const claims: QueueClaim[] = []
+    for (const name of names) {
+      if (!name.endsWith('.json')) continue
+      const parsed = JSON.parse(await readFile(join(this.claimsDir, name), 'utf8')) as QueueClaim
+      claims.push(parsed)
+    }
+    return claims
+  }
+
+  private async listResults(): Promise<AgentResult[]> {
+    const names = await readDirectoryOrEmpty(this.resultsDir)
+    const results: AgentResult[] = []
+    for (const name of names) {
+      if (!name.endsWith('.json')) continue
+      const parsed = JSON.parse(await readFile(join(this.resultsDir, name), 'utf8')) as unknown
+      results.push(validateAgentResult(parsed))
+    }
+    return results
+  }
+
+  private async appendEvent(type: QueueEventType, requestId: string, details: Record<string, unknown>): Promise<void> {
+    const event = validateQueueEvent({
+      schemaVersion: QUEUE_EVENT_SCHEMA_VERSION,
+      id: `QE-${sanitizeId(requestId)}-${sanitizeId(type)}-${this.now().getTime()}`,
+      type,
+      requestId,
+      timestamp: this.now().toISOString(),
+      actor: this.actor,
+      details,
+    })
+
+    await appendJsonLine(this.eventsPath, event)
+  }
+
+  private get requestsPath(): string {
+    return join(this.queueDir, 'requests.jsonl')
+  }
+
+  private get eventsPath(): string {
+    return join(this.queueDir, 'events.jsonl')
+  }
+
+  private get claimsDir(): string {
+    return join(this.queueDir, 'claims')
+  }
+
+  private get resultsDir(): string {
+    return join(this.queueDir, 'results')
+  }
+
+  private claimPath(requestId: string): string {
+    return join(this.claimsDir, `${sanitizeId(requestId)}.json`)
+  }
+
+  private resultPath(requestId: string): string {
+    return join(this.resultsDir, `${sanitizeId(requestId)}.json`)
+  }
+}
+
+function parseWorkGraph(data: Record<string, unknown>, issues: string[]): WorkGraphHandle {
+  const id = prefixedString(value(data, 'id'), 'WG-', 'workgraph.id', issues)
+  const nodeId = nonEmptyString(value(data, 'nodeId'), 'workgraph.nodeId', issues)
+  const sourcePrdId = optionalPrefixedString(value(data, 'sourcePrdId'), 'PRD-', 'workgraph.sourcePrdId', issues)
+  const sourceRefs = nonEmptyStringArray(value(data, 'sourceRefs'), 'workgraph.sourceRefs', issues)
+
+  if (sourceRefs.length === 0) {
+    issues.push('workgraph.sourceRefs must not be empty')
+  }
+
+  const workgraph: WorkGraphHandle = { id, nodeId, sourceRefs }
+  if (sourcePrdId) workgraph.sourcePrdId = sourcePrdId
+  return workgraph
+}
+
+function parseRepo(data: Record<string, unknown>, issues: string[]): RepoTarget {
+  const provider = oneOf(value(data, 'provider'), ['github', 'local'] as const, 'repo.provider', issues)
+  const owner = optionalNonEmptyString(value(data, 'owner'), 'repo.owner', issues)
+  const name = nonEmptyString(value(data, 'name'), 'repo.name', issues)
+  const defaultBranch = nonEmptyString(value(data, 'defaultBranch'), 'repo.defaultBranch', issues)
+  const remoteUrl = optionalNonEmptyString(value(data, 'remoteUrl'), 'repo.remoteUrl', issues)
+  const localPath = optionalNonEmptyString(value(data, 'localPath'), 'repo.localPath', issues)
+
+  if (provider === 'github' && !owner) {
+    issues.push('repo.owner is required for github repos')
+  }
+
+  if (provider === 'local' && !localPath) {
+    issues.push('repo.localPath is required for local repos')
+  }
+
+  const repo: RepoTarget = { provider, name, defaultBranch }
+  if (owner) repo.owner = owner
+  if (remoteUrl) repo.remoteUrl = remoteUrl
+  if (localPath) repo.localPath = localPath
+  return repo
+}
+
+function parseBranch(data: Record<string, unknown>, issues: string[]): BranchPolicy {
+  return {
+    mode: oneOf(value(data, 'mode'), BRANCH_MODES, 'branch.mode', issues),
+    base: nonEmptyString(value(data, 'base'), 'branch.base', issues),
+    prefix: safeBranchPrefix(value(data, 'prefix'), 'branch.prefix', issues),
+  }
+}
+
+function parsePolicy(data: Record<string, unknown>, issues: string[]): ExecutionPolicy {
+  const autonomyMode = oneOf(value(data, 'autonomyMode'), AUTONOMY_MODES, 'policy.autonomyMode', issues)
+  const allowedPaths = nonEmptyStringArray(value(data, 'allowedPaths'), 'policy.allowedPaths', issues)
+  const forbiddenActions = enumArray(value(data, 'forbiddenActions'), FORBIDDEN_ACTIONS, 'policy.forbiddenActions', issues)
+  const requiresHumanApprovalFor = enumArray(
+    value(data, 'requiresHumanApprovalFor'),
+    FORBIDDEN_ACTIONS,
+    'policy.requiresHumanApprovalFor',
+    issues,
+  )
+  const maxRuntimeMinutes = optionalPositiveInteger(value(data, 'maxRuntimeMinutes'), 'policy.maxRuntimeMinutes', issues)
+
+  validateAllowedPaths(allowedPaths, issues)
+
+  for (const required of ['merge_default_branch', 'deploy_production', 'force_push', 'edit_secrets'] as const) {
+    if (!forbiddenActions.includes(required)) {
+      issues.push(`policy.forbiddenActions must include ${required}`)
+    }
+  }
+
+  if (autonomyMode === 'multi_agent_pr' && !requiresHumanApprovalFor.includes('merge_default_branch')) {
+    issues.push('multi_agent_pr mode still requires human approval for merge_default_branch')
+  }
+
+  const policy: ExecutionPolicy = {
+    autonomyMode,
+    allowedPaths,
+    forbiddenActions,
+    requiresHumanApprovalFor,
+  }
+  if (maxRuntimeMinutes !== undefined) policy.maxRuntimeMinutes = maxRuntimeMinutes
+  return policy
+}
+
+function parseContext(data: Record<string, unknown>, issues: string[]): RequestContext {
+  const summary = nonEmptyString(value(data, 'summary'), 'context.summary', issues)
+  const artifactInputs = array(value(data, 'artifacts'), 'context.artifacts', issues)
+  const artifacts = artifactInputs.map((entry, index) => {
+    const artifact = record(entry, `context.artifacts[${index}]`, issues)
+    return {
+      id: nonEmptyString(value(artifact, 'id'), `context.artifacts[${index}].id`, issues),
+      kind: nonEmptyString(value(artifact, 'kind'), `context.artifacts[${index}].kind`, issues),
+      path: nonEmptyString(value(artifact, 'path'), `context.artifacts[${index}].path`, issues),
+    }
+  })
+
+  return { summary, artifacts }
+}
+
+function parseExpectedArtifacts(inputs: unknown[], issues: string[]): ExpectedArtifact[] {
+  return inputs.map((entry, index) => {
+    const artifact = record(entry, `expectedArtifacts[${index}]`, issues)
+    return {
+      path: relativePath(value(artifact, 'path'), `expectedArtifacts[${index}].path`, issues),
+      kind: nonEmptyString(value(artifact, 'kind'), `expectedArtifacts[${index}].kind`, issues),
+    }
+  })
+}
+
+function parseCommands(inputs: unknown[], issues: string[]): CommandEvidence[] {
+  return inputs.map((entry, index) => {
+    const command = record(entry, `commands[${index}]`, issues)
+    return {
+      command: nonEmptyString(value(command, 'command'), `commands[${index}].command`, issues),
+      exitCode: integer(value(command, 'exitCode'), `commands[${index}].exitCode`, issues),
+      outputRef: nonEmptyString(value(command, 'outputRef'), `commands[${index}].outputRef`, issues),
+    }
+  })
+}
+
+function parseEvidence(inputs: unknown[], issues: string[]): EvidenceRef[] {
+  return inputs.map((entry, index) => {
+    const evidence = record(entry, `evidence[${index}]`, issues)
+    const result: EvidenceRef = {
+      kind: oneOf(value(evidence, 'kind'), EVIDENCE_KINDS, `evidence[${index}].kind`, issues),
+      summary: nonEmptyString(value(evidence, 'summary'), `evidence[${index}].summary`, issues),
+    }
+    const path = optionalNonEmptyString(value(evidence, 'path'), `evidence[${index}].path`, issues)
+    const url = optionalNonEmptyString(value(evidence, 'url'), `evidence[${index}].url`, issues)
+    if (path) result.path = path
+    if (url) result.url = url
+    if (!path && !url) {
+      issues.push(`evidence[${index}] must include path or url`)
+    }
+    return result
+  })
+}
+
+function validateAllowedPaths(paths: string[], issues: string[]): void {
+  if (paths.length === 0) {
+    issues.push('policy.allowedPaths must not be empty')
+  }
+
+  for (const path of paths) {
+    if (path === '.' || path === './' || path === '*' || path === '**' || path === '**/*') {
+      issues.push(`policy.allowedPaths contains overly broad path: ${path}`)
+    }
+    if (path.startsWith('/')) {
+      issues.push(`policy.allowedPaths must be repo-relative: ${path}`)
+    }
+    if (path.includes('..')) {
+      issues.push(`policy.allowedPaths must not contain parent traversal: ${path}`)
+    }
+  }
+}
+
+function record(input: unknown, label: string, issues: string[]): Record<string, unknown> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    issues.push(`${label} must be an object`)
+    return {}
+  }
+  return input as Record<string, unknown>
+}
+
+function value(data: Record<string, unknown>, key: string): unknown {
+  return data[key]
+}
+
+function array(input: unknown, label: string, issues: string[]): unknown[] {
+  if (!Array.isArray(input)) {
+    issues.push(`${label} must be an array`)
+    return []
+  }
+  return input
+}
+
+function nonEmptyString(input: unknown, label: string, issues: string[]): string {
+  if (typeof input !== 'string' || input.trim().length === 0) {
+    issues.push(`${label} must be a non-empty string`)
+    return ''
+  }
+  return input
+}
+
+function optionalNonEmptyString(input: unknown, label: string, issues: string[]): string | undefined {
+  if (input === undefined) return undefined
+  return nonEmptyString(input, label, issues)
+}
+
+function prefixedString(input: unknown, prefix: string, label: string, issues: string[]): string {
+  const parsed = nonEmptyString(input, label, issues)
+  if (parsed && !parsed.startsWith(prefix)) {
+    issues.push(`${label} must start with ${prefix}`)
+  }
+  return parsed
+}
+
+function optionalPrefixedString(input: unknown, prefix: string, label: string, issues: string[]): string | undefined {
+  if (input === undefined) return undefined
+  return prefixedString(input, prefix, label, issues)
+}
+
+function safeBranchPrefix(input: unknown, label: string, issues: string[]): string {
+  const parsed = nonEmptyString(input, label, issues)
+  if (parsed.startsWith('/') || parsed.endsWith('/') || parsed.includes('..') || parsed.includes(' ')) {
+    issues.push(`${label} must be a safe git branch prefix`)
+  }
+  return parsed
+}
+
+function literal<T extends string>(input: unknown, expected: T, label: string, issues: string[]): T {
+  if (input !== expected) {
+    issues.push(`${label} must equal ${expected}`)
+  }
+  return expected
+}
+
+function oneOf<const T extends NonEmptyReadonlyArray<string>>(
+  input: unknown,
+  allowed: T,
+  label: string,
+  issues: string[],
+): T[number] {
+  const parsed = nonEmptyString(input, label, issues)
+  if (!allowed.includes(parsed)) {
+    issues.push(`${label} must be one of: ${allowed.join(', ')}`)
+    return allowed[0]
+  }
+  return parsed as T[number]
+}
+
+function enumArray<const T extends NonEmptyReadonlyArray<string>>(
+  input: unknown,
+  allowed: T,
+  label: string,
+  issues: string[],
+): T[number][] {
+  const entries = array(input, label, issues)
+  return entries.map((entry, index) => oneOf(entry, allowed, `${label}[${index}]`, issues))
+}
+
+function nonEmptyStringArray(input: unknown, label: string, issues: string[]): string[] {
+  const entries = stringArray(input, label, issues)
+  if (entries.length === 0) {
+    issues.push(`${label} must not be empty`)
+  }
+  return entries
+}
+
+function stringArray(input: unknown, label: string, issues: string[]): string[] {
+  const entries = array(input, label, issues)
+  return entries.map((entry, index) => nonEmptyString(entry, `${label}[${index}]`, issues))
+}
+
+function relativePath(input: unknown, label: string, issues: string[]): string {
+  const parsed = nonEmptyString(input, label, issues)
+  if (parsed.startsWith('/') || parsed.includes('..')) {
+    issues.push(`${label} must be a repo-relative path`)
+  }
+  return parsed
+}
+
+function integer(input: unknown, label: string, issues: string[]): number {
+  if (typeof input !== 'number' || !Number.isInteger(input)) {
+    issues.push(`${label} must be an integer`)
+    return 0
+  }
+  return input
+}
+
+function optionalPositiveInteger(input: unknown, label: string, issues: string[]): number | undefined {
+  if (input === undefined) return undefined
+  const parsed = integer(input, label, issues)
+  if (parsed <= 0) {
+    issues.push(`${label} must be greater than zero`)
+  }
+  return parsed
+}
+
+function isoString(input: unknown, label: string, issues: string[]): string {
+  const parsed = nonEmptyString(input, label, issues)
+  if (parsed && Number.isNaN(Date.parse(parsed))) {
+    issues.push(`${label} must be an ISO-parseable timestamp`)
+  }
+  return parsed
+}
+
+function throwIfIssues(message: string, issues: string[]): void {
+  if (issues.length > 0) {
+    throw new AutonomousSchedulerValidationError(message, issues)
+  }
+}
+
+async function appendJsonLine(path: string, valueToWrite: unknown): Promise<void> {
+  await appendFile(path, `${JSON.stringify(valueToWrite)}\n`, 'utf8')
+}
+
+async function readJsonLines(path: string): Promise<unknown[]> {
+  let text = ''
+  try {
+    text = await readFile(path, 'utf8')
+  } catch (error) {
+    if (isNotFound(error)) return []
+    throw error
+  }
+
+  return text
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as unknown)
+}
+
+async function readDirectoryOrEmpty(path: string): Promise<string[]> {
+  try {
+    return await readdir(path)
+  } catch (error) {
+    if (isNotFound(error)) return []
+    throw error
+  }
+}
+
+function sanitizeId(id: string): string {
+  return id.replace(/[^A-Za-z0-9_-]/g, '-')
+}
+
+function buildBranchName(request: AgentRequest): string {
+  return `${request.branch.prefix}/${sanitizeId(request.id).toLowerCase()}`
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'EEXIST'
+}

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -261,6 +261,27 @@ export interface AgentResultBundleManifest {
   }
 }
 
+export interface PullRequestPlanOptions {
+  repoRoot: string
+  title?: string
+  body?: string
+}
+
+export interface PullRequestPlan {
+  requestId: string
+  branchName: string
+  title: string
+  body: string
+  command: RunnerCommand
+}
+
+export interface PullRequestExecution {
+  requestId: string
+  branchName: string
+  prUrl: string
+  command: CommandRunResult
+}
+
 export class AutonomousSchedulerValidationError extends Error {
   public readonly issues: string[]
 
@@ -705,6 +726,71 @@ export async function writeAgentResultBundle(
 
   await writeJsonFile(manifestPath, manifest)
   return manifest
+}
+
+export function planPullRequest(
+  requestInput: unknown,
+  execution: CodexRunnerExecution,
+  options: PullRequestPlanOptions,
+): PullRequestPlan {
+  const request = validateAgentRequest(requestInput)
+
+  if (execution.requestId !== request.id) {
+    throw new Error(`Pull request plan request mismatch: ${request.id}, ${execution.requestId}`)
+  }
+
+  if (execution.status !== 'completed') {
+    throw new Error(`Pull request plan requires completed execution for ${request.id}`)
+  }
+
+  const title = options.title ?? `[Factory] ${request.objective}`
+  const body = options.body ?? buildPullRequestBody(request, execution)
+
+  return {
+    requestId: request.id,
+    branchName: execution.branchName,
+    title,
+    body,
+    command: {
+      command: 'gh',
+      args: [
+        'pr',
+        'create',
+        '--base',
+        request.branch.base,
+        '--head',
+        execution.branchName,
+        '--title',
+        title,
+        '--body',
+        body,
+      ],
+      cwd: options.repoRoot,
+    },
+  }
+}
+
+export async function executePullRequestPlan(
+  plan: PullRequestPlan,
+  executor: CommandExecutor = createProcessCommandExecutor(),
+): Promise<PullRequestExecution> {
+  const command = await executor(plan.command)
+
+  if (command.exitCode !== 0) {
+    throw new Error(`Pull request creation failed for ${plan.requestId}: ${command.stderr || command.stdout}`)
+  }
+
+  const prUrl = command.stdout.trim().split('\n').find((line) => line.startsWith('https://'))
+  if (!prUrl) {
+    throw new Error(`Pull request creation did not return a URL for ${plan.requestId}`)
+  }
+
+  return {
+    requestId: plan.requestId,
+    branchName: plan.branchName,
+    prUrl,
+    command,
+  }
 }
 
 export class JsonlAgentQueue {
@@ -1232,6 +1318,21 @@ function defaultExecutionSummary(request: AgentRequest, execution: CodexRunnerEx
   }
 
   return `Failed ${request.id} at ${execution.failedCommand ?? 'unknown command'}.`
+}
+
+function buildPullRequestBody(request: AgentRequest, execution: CodexRunnerExecution): string {
+  return [
+    `Factory request: ${request.id}`,
+    `WorkGraph: ${request.workgraph.id} / ${request.workgraph.nodeId}`,
+    `Role: ${request.role}`,
+    `Branch: ${execution.branchName}`,
+    '',
+    'Acceptance criteria:',
+    ...request.acceptanceCriteria.map((criterion, index) => `${index + 1}. ${criterion}`),
+    '',
+    'Required evidence:',
+    ...request.evidenceRequired.map((kind) => `- ${kind}`),
+  ].join('\n')
 }
 
 async function spawnCommand(command: RunnerCommand): Promise<{ exitCode: number; stdout: string; stderr: string }> {

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -306,6 +306,24 @@ export interface SingleAgentRunOutcome {
   bundle: AgentResultBundleManifest
 }
 
+export interface QueueDaemonOptions {
+  queue: JsonlAgentQueue
+  repoRoot: string
+  bundleRoot: string
+  pollIntervalMs?: number
+  maxIterations?: number
+  shouldStop?: () => boolean | Promise<boolean>
+  codexExecutor?: CommandExecutor
+  pullRequestExecutor?: CommandExecutor
+  now?: () => Date
+}
+
+export interface QueueDaemonOutcome {
+  iterations: number
+  completedRuns: number
+  stopReason: 'max_iterations' | 'stop_requested'
+}
+
 export class AutonomousSchedulerValidationError extends Error {
   public readonly issues: string[]
 
@@ -828,6 +846,16 @@ export async function runSingleAgentRequest(
     throw new Error(`Unable to claim enqueued AgentRequest: ${request.id}`)
   }
 
+  return await runClaimedAgentRequest(claimed, options)
+}
+
+export async function runClaimedAgentRequest(
+  requestInput: unknown,
+  options: SingleAgentRunOptions,
+): Promise<SingleAgentRunOutcome> {
+  const claimed = validateAgentRequest(requestInput)
+  await options.queue.heartbeat(claimed.id)
+
   const codexPlan = planCodexRunner(claimed, { repoRoot: options.repoRoot })
   const execution = await executeCodexRunnerPlan(codexPlan, options.codexExecutor)
   let pullRequest: PullRequestExecution | undefined
@@ -869,6 +897,45 @@ export async function runSingleAgentRequest(
   }
 
   return outcome
+}
+
+export async function runQueueDaemon(options: QueueDaemonOptions): Promise<QueueDaemonOutcome> {
+  const pollIntervalMs = options.pollIntervalMs ?? 5_000
+  const maxIterations = options.maxIterations ?? Number.POSITIVE_INFINITY
+  const now = options.now ?? (() => new Date())
+  let iterations = 0
+  let completedRuns = 0
+
+  while (iterations < maxIterations) {
+    if (await options.shouldStop?.()) {
+      return { iterations, completedRuns, stopReason: 'stop_requested' }
+    }
+
+    iterations += 1
+    const request = await options.queue.claimNext()
+    if (!request) {
+      await sleep(pollIntervalMs)
+      continue
+    }
+
+    const stamp = now().toISOString().replace(/[^0-9TZ]/g, '')
+    const runOptions: SingleAgentRunOptions = {
+      queue: options.queue,
+      repoRoot: options.repoRoot,
+      bundleDir: join(options.bundleRoot, sanitizeId(request.id)),
+      resultId: `ARES-${request.id.slice(3)}-${stamp}`,
+      agentRunId: `RUN-${request.id.slice(3)}-${stamp}`,
+      completedAt: now().toISOString(),
+      changedFiles: request.expectedArtifacts.map((artifact) => artifact.path),
+    }
+    if (options.codexExecutor) runOptions.codexExecutor = options.codexExecutor
+    if (options.pullRequestExecutor) runOptions.pullRequestExecutor = options.pullRequestExecutor
+
+    await runClaimedAgentRequest(request, runOptions)
+    completedRuns += 1
+  }
+
+  return { iterations, completedRuns, stopReason: 'max_iterations' }
 }
 
 export class JsonlAgentQueue {
@@ -1432,6 +1499,11 @@ async function readDirectoryOrEmpty(path: string): Promise<string[]> {
     if (isNotFound(error)) return []
     throw error
   }
+}
+
+async function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return
+  await new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 function sanitizeId(id: string): string {

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -231,6 +231,16 @@ export interface ProcessCommandExecutorOptions {
   now?: () => Date
 }
 
+export interface AgentResultFromExecutionOptions {
+  resultId: string
+  agentRunId: string
+  completedAt: string
+  artifactBasePath: string
+  prUrl?: string
+  changedFiles?: string[]
+  summary?: string
+}
+
 export class AutonomousSchedulerValidationError extends Error {
   public readonly issues: string[]
 
@@ -519,6 +529,83 @@ export function createProcessCommandExecutor(options?: ProcessCommandExecutorOpt
       completedAt,
     }
   }
+}
+
+export function buildAgentResultFromExecution(
+  requestInput: unknown,
+  execution: CodexRunnerExecution,
+  options: AgentResultFromExecutionOptions,
+): AgentResult {
+  const request = validateAgentRequest(requestInput)
+  const changedFiles = options.changedFiles ?? []
+  const commandEvidence = execution.commands.map((command, index) => ({
+    command: stringifyCommand(command),
+    exitCode: command.exitCode,
+    outputRef: join(options.artifactBasePath, `command-${index + 1}-${sanitizeId(command.command)}.txt`),
+  }))
+
+  const evidence: EvidenceRef[] = [
+    {
+      kind: 'artifact_paths',
+      path: join(options.artifactBasePath, 'manifest.json'),
+      summary: 'Runner artifact manifest.',
+    },
+  ]
+
+  if (execution.commands.some((command) => stringifyCommand(command).includes('test'))) {
+    evidence.push({
+      kind: 'test_output',
+      path: join(options.artifactBasePath, 'test-output.txt'),
+      summary: 'Test command output captured by runner.',
+    })
+  }
+
+  if (execution.commands.some((command) => stringifyCommand(command).includes('typecheck'))) {
+    evidence.push({
+      kind: 'typecheck_output',
+      path: join(options.artifactBasePath, 'typecheck-output.txt'),
+      summary: 'Typecheck command output captured by runner.',
+    })
+  }
+
+  if (execution.status === 'completed') {
+    evidence.push({
+      kind: 'git_diff',
+      path: join(options.artifactBasePath, 'diff.patch'),
+      summary: 'Git diff captured after worker execution.',
+    })
+
+    if (options.prUrl) {
+      evidence.push({
+        kind: 'pr_url',
+        url: options.prUrl,
+        summary: 'Pull request opened for worker output.',
+      })
+    }
+  }
+
+  const result: AgentResult = {
+    schemaVersion: AGENT_RESULT_SCHEMA_VERSION,
+    id: options.resultId,
+    requestId: request.id,
+    agentRunId: options.agentRunId,
+    status: execution.status,
+    completedAt: options.completedAt,
+    summary: options.summary ?? defaultExecutionSummary(request, execution),
+    changedFiles,
+    commands: commandEvidence,
+    evidence,
+  }
+
+  if (execution.status === 'completed') {
+    result.branchName = execution.branchName
+  }
+
+  if (options.prUrl) {
+    result.prUrl = options.prUrl
+  }
+
+  return validateAgentResult(result)
 }
 
 export class JsonlAgentQueue {
@@ -1034,6 +1121,14 @@ function buildBranchName(request: AgentRequest): string {
 
 function stringifyCommand(command: RunnerCommand): string {
   return [command.command, ...command.args].join(' ')
+}
+
+function defaultExecutionSummary(request: AgentRequest, execution: CodexRunnerExecution): string {
+  if (execution.status === 'completed') {
+    return `Completed ${request.id} on branch ${execution.branchName}.`
+  }
+
+  return `Failed ${request.id} at ${execution.failedCommand ?? 'unknown command'}.`
 }
 
 async function spawnCommand(command: RunnerCommand): Promise<{ exitCode: number; stdout: string; stderr: string }> {

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -234,6 +234,12 @@ export interface ProcessCommandExecutorOptions {
   now?: () => Date
 }
 
+export interface DryRunCommandExecutorOptions {
+  now?: () => Date
+  prUrl?: string
+  failCommandIncludes?: string
+}
+
 export interface AgentResultFromExecutionOptions {
   resultId: string
   agentRunId: string
@@ -610,6 +616,30 @@ export function createProcessCommandExecutor(options?: ProcessCommandExecutorOpt
       stderr,
       startedAt,
       completedAt,
+    }
+  }
+}
+
+export function createDryRunCommandExecutor(options?: DryRunCommandExecutorOptions): CommandExecutor {
+  const now = options?.now ?? (() => new Date())
+  const prUrl = options?.prUrl ?? 'https://github.com/Wescome/strategy-recipes/pull/dry-run'
+
+  return async (command: RunnerCommand): Promise<CommandRunResult> => {
+    const commandText = stringifyCommand(command)
+    const shouldFail = options?.failCommandIncludes ? commandText.includes(options.failCommandIncludes) : false
+    const stdout = command.command === 'gh'
+      ? `${prUrl}\n`
+      : `dry-run: ${commandText}\n`
+
+    return {
+      command: command.command,
+      args: command.args,
+      cwd: command.cwd,
+      exitCode: shouldFail ? 1 : 0,
+      stdout,
+      stderr: shouldFail ? `dry-run failure for ${commandText}` : '',
+      startedAt: now().toISOString(),
+      completedAt: now().toISOString(),
     }
   }
 }

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -167,6 +167,7 @@ export interface QueueEvent {
 export interface JsonlAgentQueueOptions {
   queueDir: string
   actor: string
+  leaseMs?: number
   now?: () => Date
 }
 
@@ -174,6 +175,8 @@ export interface QueueClaim {
   requestId: string
   actor: string
   claimedAt: string
+  heartbeatAt: string
+  leaseExpiresAt: string
 }
 
 export interface JsonlQueueStatus {
@@ -871,11 +874,13 @@ export async function runSingleAgentRequest(
 export class JsonlAgentQueue {
   private readonly queueDir: string
   private readonly actor: string
+  private readonly leaseMs: number
   private readonly now: () => Date
 
   public constructor(options: JsonlAgentQueueOptions) {
     this.queueDir = options.queueDir
     this.actor = options.actor
+    this.leaseMs = options.leaseMs ?? 15 * 60 * 1000
     this.now = options.now ?? (() => new Date())
   }
 
@@ -924,26 +929,55 @@ export class JsonlAgentQueue {
       if (completed.has(request.id)) continue
 
       const claimPath = this.claimPath(request.id)
-      const claim: QueueClaim = {
-        requestId: request.id,
-        actor: this.actor,
-        claimedAt: this.now().toISOString(),
-      }
+      const claim = this.createClaim(request.id)
 
       try {
         await writeFile(claimPath, `${JSON.stringify(claim, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' })
         await this.appendEvent('request.claimed', request.id, {
           actor: this.actor,
           claimPath,
+          reclaimed: false,
         })
         return request
       } catch (error) {
-        if (isAlreadyExists(error)) continue
-        throw error
+        if (!isAlreadyExists(error)) throw error
+        const existingClaim = await this.readClaim(request.id)
+        if (existingClaim && this.isClaimActive(existingClaim)) continue
+        await writeFile(claimPath, `${JSON.stringify(claim, null, 2)}\n`, 'utf8')
+        await this.appendEvent('request.claimed', request.id, {
+          actor: this.actor,
+          claimPath,
+          reclaimed: true,
+        })
+        return request
       }
     }
 
     return null
+  }
+
+  public async heartbeat(requestId: string): Promise<QueueClaim> {
+    await this.init()
+    const existing = await this.readClaim(requestId)
+    if (!existing) {
+      throw new Error(`Cannot heartbeat unclaimed request: ${requestId}`)
+    }
+
+    const now = this.now()
+    const updated: QueueClaim = {
+      ...existing,
+      actor: this.actor,
+      heartbeatAt: now.toISOString(),
+      leaseExpiresAt: new Date(now.getTime() + this.leaseMs).toISOString(),
+    }
+
+    await writeFile(this.claimPath(requestId), `${JSON.stringify(updated, null, 2)}\n`, 'utf8')
+    await this.appendEvent('request.heartbeat', requestId, {
+      actor: this.actor,
+      leaseExpiresAt: updated.leaseExpiresAt,
+    })
+
+    return updated
   }
 
   public async complete(input: unknown): Promise<AgentResult> {
@@ -979,8 +1013,9 @@ export class JsonlAgentQueue {
     const completed = results.filter((result) => result.status === 'completed').length
     const failed = results.filter((result) => result.status === 'failed').length
     const refused = results.filter((result) => result.status === 'refused').length
-    const claimed = requests.filter((request) => claimedRequestIds.has(request.id) && !resultRequestIds.has(request.id)).length
-    const pending = requests.filter((request) => !claimedRequestIds.has(request.id) && !resultRequestIds.has(request.id)).length
+    const activeClaimIds = new Set(claims.filter((claim) => this.isClaimActive(claim)).map((claim) => claim.requestId))
+    const claimed = requests.filter((request) => activeClaimIds.has(request.id) && !resultRequestIds.has(request.id)).length
+    const pending = requests.filter((request) => !activeClaimIds.has(request.id) && !resultRequestIds.has(request.id)).length
 
     return {
       queueDir: this.queueDir,
@@ -1002,6 +1037,15 @@ export class JsonlAgentQueue {
       claims.push(parsed)
     }
     return claims
+  }
+
+  private async readClaim(requestId: string): Promise<QueueClaim | null> {
+    try {
+      return JSON.parse(await readFile(this.claimPath(requestId), 'utf8')) as QueueClaim
+    } catch (error) {
+      if (isNotFound(error)) return null
+      throw error
+    }
   }
 
   private async listResults(): Promise<AgentResult[]> {
@@ -1027,6 +1071,21 @@ export class JsonlAgentQueue {
     })
 
     await appendJsonLine(this.eventsPath, event)
+  }
+
+  private createClaim(requestId: string): QueueClaim {
+    const now = this.now()
+    return {
+      requestId,
+      actor: this.actor,
+      claimedAt: now.toISOString(),
+      heartbeatAt: now.toISOString(),
+      leaseExpiresAt: new Date(now.getTime() + this.leaseMs).toISOString(),
+    }
+  }
+
+  private isClaimActive(claim: QueueClaim): boolean {
+    return Date.parse(claim.leaseExpiresAt) > this.now().getTime()
   }
 
   private get requestsPath(): string {

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -241,6 +241,26 @@ export interface AgentResultFromExecutionOptions {
   summary?: string
 }
 
+export interface AgentResultBundleOptions {
+  bundleDir: string
+  diff?: string
+}
+
+export interface AgentResultBundleManifest {
+  schemaVersion: 'factory.agent-result-bundle.v0'
+  requestId: string
+  resultId: string
+  bundleDir: string
+  files: {
+    request: string
+    execution: string
+    result: string
+    manifest: string
+    commands: string[]
+    diff?: string
+  }
+}
+
 export class AutonomousSchedulerValidationError extends Error {
   public readonly issues: string[]
 
@@ -606,6 +626,85 @@ export function buildAgentResultFromExecution(
   }
 
   return validateAgentResult(result)
+}
+
+export async function writeAgentResultBundle(
+  requestInput: unknown,
+  execution: CodexRunnerExecution,
+  resultInput: unknown,
+  options: AgentResultBundleOptions,
+): Promise<AgentResultBundleManifest> {
+  const request = validateAgentRequest(requestInput)
+  const result = validateAgentResult(resultInput)
+
+  if (request.id !== execution.requestId || request.id !== result.requestId) {
+    throw new Error(`Bundle request mismatch: ${request.id}, ${execution.requestId}, ${result.requestId}`)
+  }
+
+  await mkdir(options.bundleDir, { recursive: true })
+
+  const requestPath = join(options.bundleDir, 'request.json')
+  const executionPath = join(options.bundleDir, 'execution.json')
+  const resultPath = join(options.bundleDir, 'result.json')
+  const manifestPath = join(options.bundleDir, 'manifest.json')
+  const commandPaths: string[] = []
+
+  await writeJsonFile(requestPath, request)
+  await writeJsonFile(executionPath, execution)
+  await writeJsonFile(resultPath, result)
+
+  for (let index = 0; index < execution.commands.length; index += 1) {
+    const command = execution.commands[index]
+    if (!command) continue
+    const outputPath = join(options.bundleDir, `command-${index + 1}-${sanitizeId(command.command)}.txt`)
+    commandPaths.push(outputPath)
+    await writeFile(
+      outputPath,
+      [
+        `$ ${stringifyCommand(command)}`,
+        '',
+        `exitCode: ${command.exitCode}`,
+        `cwd: ${command.cwd}`,
+        `startedAt: ${command.startedAt}`,
+        `completedAt: ${command.completedAt}`,
+        '',
+        'stdout:',
+        command.stdout,
+        '',
+        'stderr:',
+        command.stderr,
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+  }
+
+  let diffPath: string | undefined
+  if (options.diff !== undefined) {
+    diffPath = join(options.bundleDir, 'diff.patch')
+    await writeFile(diffPath, options.diff, 'utf8')
+  }
+
+  const manifest: AgentResultBundleManifest = {
+    schemaVersion: 'factory.agent-result-bundle.v0',
+    requestId: request.id,
+    resultId: result.id,
+    bundleDir: options.bundleDir,
+    files: {
+      request: requestPath,
+      execution: executionPath,
+      result: resultPath,
+      manifest: manifestPath,
+      commands: commandPaths,
+    },
+  }
+
+  if (diffPath) {
+    manifest.files.diff = diffPath
+  }
+
+  await writeJsonFile(manifestPath, manifest)
+  return manifest
 }
 
 export class JsonlAgentQueue {
@@ -1085,6 +1184,10 @@ function throwIfIssues(message: string, issues: string[]): void {
 
 async function appendJsonLine(path: string, valueToWrite: unknown): Promise<void> {
   await appendFile(path, `${JSON.stringify(valueToWrite)}\n`, 'utf8')
+}
+
+async function writeJsonFile(path: string, valueToWrite: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(valueToWrite, null, 2)}\n`, 'utf8')
 }
 
 async function readJsonLines(path: string): Promise<unknown[]> {

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -282,6 +282,27 @@ export interface PullRequestExecution {
   command: CommandRunResult
 }
 
+export interface SingleAgentRunOptions {
+  queue: JsonlAgentQueue
+  repoRoot: string
+  bundleDir: string
+  resultId: string
+  agentRunId: string
+  completedAt: string
+  changedFiles?: string[]
+  diff?: string
+  codexExecutor?: CommandExecutor
+  pullRequestExecutor?: CommandExecutor
+}
+
+export interface SingleAgentRunOutcome {
+  request: AgentRequest
+  execution: CodexRunnerExecution
+  pullRequest?: PullRequestExecution
+  result: AgentResult
+  bundle: AgentResultBundleManifest
+}
+
 export class AutonomousSchedulerValidationError extends Error {
   public readonly issues: string[]
 
@@ -791,6 +812,60 @@ export async function executePullRequestPlan(
     prUrl,
     command,
   }
+}
+
+export async function runSingleAgentRequest(
+  requestInput: unknown,
+  options: SingleAgentRunOptions,
+): Promise<SingleAgentRunOutcome> {
+  const request = await options.queue.enqueue(requestInput)
+  const claimed = await options.queue.claimNext()
+
+  if (!claimed || claimed.id !== request.id) {
+    throw new Error(`Unable to claim enqueued AgentRequest: ${request.id}`)
+  }
+
+  const codexPlan = planCodexRunner(claimed, { repoRoot: options.repoRoot })
+  const execution = await executeCodexRunnerPlan(codexPlan, options.codexExecutor)
+  let pullRequest: PullRequestExecution | undefined
+
+  if (execution.status === 'completed') {
+    const prPlan = planPullRequest(claimed, execution, { repoRoot: options.repoRoot })
+    pullRequest = await executePullRequestPlan(prPlan, options.pullRequestExecutor)
+  }
+
+  const resultOptions: AgentResultFromExecutionOptions = {
+    resultId: options.resultId,
+    agentRunId: options.agentRunId,
+    completedAt: options.completedAt,
+    artifactBasePath: options.bundleDir,
+  }
+  if (pullRequest) resultOptions.prUrl = pullRequest.prUrl
+  if (options.changedFiles) resultOptions.changedFiles = options.changedFiles
+
+  const result = buildAgentResultFromExecution(claimed, execution, resultOptions)
+
+  const bundleOptions: AgentResultBundleOptions = {
+    bundleDir: options.bundleDir,
+  }
+  if (options.diff !== undefined) bundleOptions.diff = options.diff
+
+  const bundle = await writeAgentResultBundle(claimed, execution, result, bundleOptions)
+
+  await options.queue.complete(result)
+
+  const outcome: SingleAgentRunOutcome = {
+    request: claimed,
+    execution,
+    result,
+    bundle,
+  }
+
+  if (pullRequest) {
+    outcome.pullRequest = pullRequest
+  }
+
+  return outcome
 }
 
 export class JsonlAgentQueue {

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -7,6 +7,7 @@ import {
   JsonlAgentQueue,
   buildAgentResultFromExecution,
   buildCodexWorkerPrompt,
+  createDryRunCommandExecutor,
   executeCodexRunnerPlan,
   executePullRequestPlan,
   planCodexRunner,
@@ -193,6 +194,22 @@ describe('Codex runner planning', () => {
     expect(execution.failedCommand).toBe(
       'git switch -c factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view origin/main',
     )
+  })
+
+  it('supports dry-run command execution without invoking external tools', async () => {
+    const plan = planCodexRunner(requestFixture, { repoRoot: '/tmp/strategy-recipes' })
+    const executor = createDryRunCommandExecutor({
+      prUrl: 'https://github.com/Wescome/strategy-recipes/pull/dry-run',
+      now: fixedClock(),
+    })
+    const execution = await executeCodexRunnerPlan(plan, executor)
+    const pr = await executePullRequestPlan(planPullRequest(requestFixture, execution, {
+      repoRoot: '/tmp/strategy-recipes',
+    }), executor)
+
+    expect(execution.status).toBe('completed')
+    expect(execution.commands[0]?.stdout).toContain('dry-run: git fetch')
+    expect(pr.prUrl).toBe('https://github.com/Wescome/strategy-recipes/pull/dry-run')
   })
 
   it('builds a validated completed AgentResult from runner execution', async () => {

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -1,0 +1,228 @@
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  AutonomousSchedulerValidationError,
+  JsonlAgentQueue,
+  buildCodexWorkerPrompt,
+  planCodexRunner,
+  validateAgentRequest,
+  validateAgentResult,
+  validateQueueEvent,
+} from '../src/index.js'
+
+const requestFixture = JSON.parse(
+  readFileSync(new URL('../fixtures/strategy-recipes-agent-request.json', import.meta.url), 'utf8'),
+) as unknown
+
+const resultFixture = JSON.parse(
+  readFileSync(new URL('../fixtures/strategy-recipes-agent-result.json', import.meta.url), 'utf8'),
+) as unknown
+
+describe('autonomous scheduler contracts', () => {
+  it('validates the Strategy.Recipes dogfood AgentRequest fixture', () => {
+    const request = validateAgentRequest(requestFixture)
+
+    expect(request.id).toBe('AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
+    expect(request.role).toBe('builder')
+    expect(request.repo.name).toBe('strategy-recipes')
+    expect(request.branch.mode).toBe('new_pr_branch')
+    expect(request.policy.autonomyMode).toBe('branch_pr')
+    expect(request.workgraph.sourceRefs).toContain('Strategy_Recipes_UX_Architecture_v1.1.md')
+  })
+
+  it('validates a completed AgentResult with PR evidence', () => {
+    const result = validateAgentResult(resultFixture)
+
+    expect(result.status).toBe('completed')
+    expect(result.requestId).toBe('AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
+    expect(result.prUrl).toBe('https://github.com/Wescome/strategy-recipes/pull/1')
+    expect(result.evidence.some((entry) => entry.kind === 'pr_url')).toBe(true)
+  })
+
+  it('validates queue events for the jsonl queue boundary', () => {
+    const event = validateQueueEvent({
+      schemaVersion: 'factory.queue-event.v0',
+      id: 'QE-STRATEGY-RECIPES-ENQUEUED',
+      type: 'request.enqueued',
+      requestId: 'AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW',
+      timestamp: '2026-04-30T14:01:00.000Z',
+      actor: 'factory-governor',
+      details: {
+        queue: 'jsonl_queue',
+        branchMode: 'new_pr_branch',
+      },
+    })
+
+    expect(event.type).toBe('request.enqueued')
+    expect(event.details.queue).toBe('jsonl_queue')
+  })
+
+  it('rejects requests without WorkGraph lineage', () => {
+    const invalid = structuredClone(requestFixture) as Record<string, unknown>
+    invalid.workgraph = {
+      id: 'WG-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW',
+      nodeId: 'first-product-view',
+      sourceRefs: [],
+    }
+
+    expectValidationIssues(() => validateAgentRequest(invalid), ['workgraph.sourceRefs must not be empty'])
+  })
+
+  it('rejects broad or absolute allowed paths', () => {
+    const invalid = structuredClone(requestFixture) as Record<string, unknown>
+    invalid.policy = {
+      ...(invalid.policy as Record<string, unknown>),
+      allowedPaths: ['**', '/tmp/work'],
+    }
+
+    expectValidationIssues(() => validateAgentRequest(invalid), [
+      'policy.allowedPaths contains overly broad path: **',
+      'policy.allowedPaths must be repo-relative: /tmp/work',
+    ])
+  })
+
+  it('rejects policies that omit default-branch and secret safeguards', () => {
+    const invalid = structuredClone(requestFixture) as Record<string, unknown>
+    invalid.policy = {
+      ...(invalid.policy as Record<string, unknown>),
+      forbiddenActions: ['delete_remote_branch'],
+    }
+
+    expectValidationIssues(() => validateAgentRequest(invalid), [
+      'policy.forbiddenActions must include merge_default_branch',
+      'policy.forbiddenActions must include deploy_production',
+      'policy.forbiddenActions must include force_push',
+      'policy.forbiddenActions must include edit_secrets',
+    ])
+  })
+})
+
+describe('Codex runner planning', () => {
+  it('plans a PR-branch Codex runner invocation from an AgentRequest', () => {
+    const plan = planCodexRunner(requestFixture, {
+      repoRoot: '/tmp/strategy-recipes',
+      codexBinary: 'codex',
+    })
+
+    expect(plan.requestId).toBe('AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
+    expect(plan.branchName).toBe('factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view')
+    expect(plan.preflightCommands.map((command) => command.command)).toEqual(['git', 'git', 'git'])
+    expect(plan.preflightCommands[1]?.args).toEqual([
+      'switch',
+      '-c',
+      'factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view',
+      'origin/main',
+    ])
+    expect(plan.codexCommand.command).toBe('codex')
+    expect(plan.codexCommand.args[0]).toBe('exec')
+    expect(plan.prompt).toContain('Allowed paths: README.md, docs/**, packages/**, apps/**, examples/**, tests/**')
+    expect(plan.prompt).toContain('Do not merge, deploy, force-push, delete remote branches, edit secrets')
+  })
+
+  it('builds a worker prompt with required commands and evidence', () => {
+    const prompt = buildCodexWorkerPrompt(requestFixture)
+
+    expect(prompt).toContain('Required commands:')
+    expect(prompt).toContain('- pnpm test')
+    expect(prompt).toContain('Required evidence:')
+    expect(prompt).toContain('- pr_url')
+  })
+
+  it('does not plan execution for enqueue-only requests', () => {
+    const invalid = structuredClone(requestFixture) as Record<string, unknown>
+    invalid.policy = {
+      ...(invalid.policy as Record<string, unknown>),
+      autonomyMode: 'enqueue_only',
+    }
+
+    expect(() => planCodexRunner(invalid, { repoRoot: '/tmp/strategy-recipes' })).toThrow(
+      'Codex runner cannot execute autonomyMode=enqueue_only',
+    )
+  })
+})
+
+describe('JsonlAgentQueue', () => {
+  it('enqueues, claims, completes, and records events', async () => {
+    const queueDir = mkdtempSync(join(tmpdir(), 'factory-autonomous-'))
+    const queue = new JsonlAgentQueue({
+      queueDir,
+      actor: 'factory-governor',
+      now: fixedClock(),
+    })
+
+    await queue.enqueue(requestFixture)
+    expect(await queue.status()).toMatchObject({
+      total: 1,
+      pending: 1,
+      claimed: 0,
+      completed: 0,
+    })
+
+    const claimed = await queue.claimNext()
+    expect(claimed?.id).toBe('AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
+    expect(await queue.claimNext()).toBeNull()
+    expect(await queue.status()).toMatchObject({
+      total: 1,
+      pending: 0,
+      claimed: 1,
+      completed: 0,
+    })
+
+    await queue.complete(resultFixture)
+    expect(await queue.status()).toMatchObject({
+      total: 1,
+      pending: 0,
+      claimed: 0,
+      completed: 1,
+      failed: 0,
+      refused: 0,
+    })
+
+    const events = await queue.listEvents()
+    expect(events.map((event) => event.type)).toEqual([
+      'request.enqueued',
+      'request.claimed',
+      'request.completed',
+    ])
+
+    const requestsFile = readFileSync(join(queueDir, 'requests.jsonl'), 'utf8')
+    expect(requestsFile).toContain('AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
+  })
+
+  it('rejects duplicate request IDs', async () => {
+    const queue = new JsonlAgentQueue({
+      queueDir: mkdtempSync(join(tmpdir(), 'factory-autonomous-')),
+      actor: 'factory-governor',
+      now: fixedClock(),
+    })
+
+    await queue.enqueue(requestFixture)
+
+    await expect(queue.enqueue(requestFixture)).rejects.toThrow(
+      'AgentRequest already exists in queue: AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW',
+    )
+  })
+})
+
+function expectValidationIssues(action: () => unknown, expectedIssues: string[]): void {
+  expect(action).toThrow(AutonomousSchedulerValidationError)
+
+  try {
+    action()
+  } catch (error) {
+    expect(error).toBeInstanceOf(AutonomousSchedulerValidationError)
+    const validationError = error as AutonomousSchedulerValidationError
+    for (const issue of expectedIssues) {
+      expect(validationError.issues).toContain(issue)
+    }
+    return
+  }
+
+  throw new Error('expected validation error')
+}
+
+function fixedClock(): () => Date {
+  return () => new Date('2026-04-30T14:30:00.000Z')
+}

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -12,6 +12,7 @@ import {
   validateAgentRequest,
   validateAgentResult,
   validateQueueEvent,
+  writeAgentResultBundle,
 } from '../src/index.js'
 
 const requestFixture = JSON.parse(
@@ -241,6 +242,42 @@ describe('Codex runner planning', () => {
         changedFiles: ['docs/product/first-product-view.md'],
       }),
     ).toThrow(AutonomousSchedulerValidationError)
+  })
+
+  it('writes a durable AgentResult artifact bundle', async () => {
+    const queueDir = mkdtempSync(join(tmpdir(), 'factory-autonomous-'))
+    const bundleDir = join(queueDir, 'bundle')
+    const plan = planCodexRunner(requestFixture, { repoRoot: '/tmp/strategy-recipes' })
+    const execution = await executeCodexRunnerPlan(plan, async (command) => ({
+      command: command.command,
+      args: command.args,
+      cwd: command.cwd,
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+      startedAt: '2026-04-30T14:30:00.000Z',
+      completedAt: '2026-04-30T14:30:01.000Z',
+    }))
+    const result = buildAgentResultFromExecution(requestFixture, execution, {
+      resultId: 'ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-BUNDLE',
+      agentRunId: 'RUN-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-004',
+      completedAt: '2026-04-30T14:35:00.000Z',
+      artifactBasePath: bundleDir,
+      prUrl: 'https://github.com/Wescome/strategy-recipes/pull/3',
+      changedFiles: ['docs/product/first-product-view.md'],
+    })
+
+    const manifest = await writeAgentResultBundle(requestFixture, execution, result, {
+      bundleDir,
+      diff: 'diff --git a/docs/product/first-product-view.md b/docs/product/first-product-view.md',
+    })
+
+    expect(manifest.schemaVersion).toBe('factory.agent-result-bundle.v0')
+    expect(manifest.files.commands).toHaveLength(4)
+    expect(readFileSync(manifest.files.request, 'utf8')).toContain('AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
+    expect(readFileSync(manifest.files.result, 'utf8')).toContain('ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-BUNDLE')
+    expect(readFileSync(manifest.files.commands[0] ?? '', 'utf8')).toContain('stdout:')
+    expect(readFileSync(manifest.files.diff ?? '', 'utf8')).toContain('diff --git')
   })
 })
 

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -11,6 +11,7 @@ import {
   executePullRequestPlan,
   planCodexRunner,
   planPullRequest,
+  runSingleAgentRequest,
   validateAgentRequest,
   validateAgentResult,
   validateQueueEvent,
@@ -393,6 +394,113 @@ describe('JsonlAgentQueue', () => {
     await expect(queue.enqueue(requestFixture)).rejects.toThrow(
       'AgentRequest already exists in queue: AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW',
     )
+  })
+})
+
+describe('single-request scheduler run', () => {
+  it('drives one request through queue, runner, PR creation, result, and bundle', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'factory-autonomous-'))
+    const queue = new JsonlAgentQueue({
+      queueDir: join(home, 'queue'),
+      actor: 'factory-governor',
+      now: fixedClock(),
+    })
+    const codexCommands: string[] = []
+
+    const outcome = await runSingleAgentRequest(requestFixture, {
+      queue,
+      repoRoot: '/tmp/strategy-recipes',
+      bundleDir: join(home, 'bundle'),
+      resultId: 'ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-RUN',
+      agentRunId: 'RUN-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-005',
+      completedAt: '2026-04-30T14:40:00.000Z',
+      changedFiles: ['docs/product/first-product-view.md'],
+      diff: 'diff --git a/docs/product/first-product-view.md b/docs/product/first-product-view.md',
+      codexExecutor: async (command) => {
+        codexCommands.push(command.command)
+        return {
+          command: command.command,
+          args: command.args,
+          cwd: command.cwd,
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+          startedAt: '2026-04-30T14:30:00.000Z',
+          completedAt: '2026-04-30T14:30:01.000Z',
+        }
+      },
+      pullRequestExecutor: async (command) => ({
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: 0,
+        stdout: 'https://github.com/Wescome/strategy-recipes/pull/5\n',
+        stderr: '',
+        startedAt: '2026-04-30T14:36:00.000Z',
+        completedAt: '2026-04-30T14:36:01.000Z',
+      }),
+    })
+
+    expect(codexCommands).toEqual(['git', 'git', 'git', 'codex'])
+    expect(outcome.result.status).toBe('completed')
+    expect(outcome.pullRequest?.prUrl).toBe('https://github.com/Wescome/strategy-recipes/pull/5')
+    expect(readFileSync(outcome.bundle.files.manifest, 'utf8')).toContain('factory.agent-result-bundle.v0')
+    expect(await queue.status()).toMatchObject({
+      total: 1,
+      pending: 0,
+      claimed: 0,
+      completed: 1,
+    })
+  })
+
+  it('completes the queue with a failed result when Codex execution fails', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'factory-autonomous-'))
+    const queue = new JsonlAgentQueue({
+      queueDir: join(home, 'queue'),
+      actor: 'factory-governor',
+      now: fixedClock(),
+    })
+    let prCalls = 0
+
+    const outcome = await runSingleAgentRequest(requestFixture, {
+      queue,
+      repoRoot: '/tmp/strategy-recipes',
+      bundleDir: join(home, 'bundle'),
+      resultId: 'ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-FAILED-RUN',
+      agentRunId: 'RUN-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-006',
+      completedAt: '2026-04-30T14:40:00.000Z',
+      codexExecutor: async (command) => ({
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: command.command === 'codex' ? 1 : 0,
+        stdout: '',
+        stderr: command.command === 'codex' ? 'worker failed' : '',
+        startedAt: '2026-04-30T14:30:00.000Z',
+        completedAt: '2026-04-30T14:30:01.000Z',
+      }),
+      pullRequestExecutor: async (command) => {
+        prCalls += 1
+        return {
+          command: command.command,
+          args: command.args,
+          cwd: command.cwd,
+          exitCode: 0,
+          stdout: 'https://github.com/Wescome/strategy-recipes/pull/6\n',
+          stderr: '',
+          startedAt: '2026-04-30T14:36:00.000Z',
+          completedAt: '2026-04-30T14:36:01.000Z',
+        }
+      },
+    })
+
+    expect(outcome.result.status).toBe('failed')
+    expect(outcome.pullRequest).toBeUndefined()
+    expect(prCalls).toBe(0)
+    expect(await queue.status()).toMatchObject({
+      total: 1,
+      failed: 1,
+    })
   })
 })
 

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -8,7 +8,9 @@ import {
   buildAgentResultFromExecution,
   buildCodexWorkerPrompt,
   executeCodexRunnerPlan,
+  executePullRequestPlan,
   planCodexRunner,
+  planPullRequest,
   validateAgentRequest,
   validateAgentResult,
   validateQueueEvent,
@@ -278,6 +280,56 @@ describe('Codex runner planning', () => {
     expect(readFileSync(manifest.files.result, 'utf8')).toContain('ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-BUNDLE')
     expect(readFileSync(manifest.files.commands[0] ?? '', 'utf8')).toContain('stdout:')
     expect(readFileSync(manifest.files.diff ?? '', 'utf8')).toContain('diff --git')
+  })
+
+  it('plans and executes pull request creation through the command seam', async () => {
+    const codexPlan = planCodexRunner(requestFixture, { repoRoot: '/tmp/strategy-recipes' })
+    const execution = await executeCodexRunnerPlan(codexPlan, async (command) => ({
+      command: command.command,
+      args: command.args,
+      cwd: command.cwd,
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      startedAt: '2026-04-30T14:30:00.000Z',
+      completedAt: '2026-04-30T14:30:01.000Z',
+    }))
+
+    const prPlan = planPullRequest(requestFixture, execution, { repoRoot: '/tmp/strategy-recipes' })
+    expect(prPlan.command.command).toBe('gh')
+    expect(prPlan.command.args.slice(0, 3)).toEqual(['pr', 'create', '--base'])
+    expect(prPlan.command.args).toContain('main')
+    expect(prPlan.command.args).toContain('factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view')
+    expect(prPlan.body).toContain('Factory request: AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
+
+    const pr = await executePullRequestPlan(prPlan, async (command) => ({
+      command: command.command,
+      args: command.args,
+      cwd: command.cwd,
+      exitCode: 0,
+      stdout: 'https://github.com/Wescome/strategy-recipes/pull/4\n',
+      stderr: '',
+      startedAt: '2026-04-30T14:36:00.000Z',
+      completedAt: '2026-04-30T14:36:01.000Z',
+    }))
+
+    expect(pr.prUrl).toBe('https://github.com/Wescome/strategy-recipes/pull/4')
+  })
+
+  it('does not plan PR creation for failed executions', async () => {
+    expect(() =>
+      planPullRequest(
+        requestFixture,
+        {
+          requestId: 'AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW',
+          branchName: 'factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view',
+          status: 'failed',
+          commands: [],
+          failedCommand: 'codex exec',
+        },
+        { repoRoot: '/tmp/strategy-recipes' },
+      ),
+    ).toThrow('Pull request plan requires completed execution for AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
   })
 })
 

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 import {
   AutonomousSchedulerValidationError,
   JsonlAgentQueue,
+  buildAgentResultFromExecution,
   buildCodexWorkerPrompt,
   executeCodexRunnerPlan,
   planCodexRunner,
@@ -187,6 +188,59 @@ describe('Codex runner planning', () => {
     expect(execution.failedCommand).toBe(
       'git switch -c factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view origin/main',
     )
+  })
+
+  it('builds a validated completed AgentResult from runner execution', async () => {
+    const plan = planCodexRunner(requestFixture, { repoRoot: '/tmp/strategy-recipes' })
+    const execution = await executeCodexRunnerPlan(plan, async (command) => ({
+      command: command.command,
+      args: command.args,
+      cwd: command.cwd,
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      startedAt: '2026-04-30T14:30:00.000Z',
+      completedAt: '2026-04-30T14:30:01.000Z',
+    }))
+
+    const result = buildAgentResultFromExecution(requestFixture, execution, {
+      resultId: 'ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-EXECUTION',
+      agentRunId: 'RUN-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-002',
+      completedAt: '2026-04-30T14:35:00.000Z',
+      artifactBasePath: 'artifacts/AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW',
+      prUrl: 'https://github.com/Wescome/strategy-recipes/pull/2',
+      changedFiles: ['docs/product/first-product-view.md'],
+    })
+
+    expect(result.status).toBe('completed')
+    expect(result.prUrl).toBe('https://github.com/Wescome/strategy-recipes/pull/2')
+    expect(result.branchName).toBe('factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view')
+    expect(result.evidence.map((entry) => entry.kind)).toContain('pr_url')
+    expect(result.evidence.map((entry) => entry.kind)).toContain('git_diff')
+  })
+
+  it('requires PR evidence for completed runner results', async () => {
+    const plan = planCodexRunner(requestFixture, { repoRoot: '/tmp/strategy-recipes' })
+    const execution = await executeCodexRunnerPlan(plan, async (command) => ({
+      command: command.command,
+      args: command.args,
+      cwd: command.cwd,
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      startedAt: '2026-04-30T14:30:00.000Z',
+      completedAt: '2026-04-30T14:30:01.000Z',
+    }))
+
+    expect(() =>
+      buildAgentResultFromExecution(requestFixture, execution, {
+        resultId: 'ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-MISSING-PR',
+        agentRunId: 'RUN-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-003',
+        completedAt: '2026-04-30T14:35:00.000Z',
+        artifactBasePath: 'artifacts/AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW',
+        changedFiles: ['docs/product/first-product-view.md'],
+      }),
+    ).toThrow(AutonomousSchedulerValidationError)
   })
 })
 

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -6,6 +6,7 @@ import {
   AutonomousSchedulerValidationError,
   JsonlAgentQueue,
   buildCodexWorkerPrompt,
+  executeCodexRunnerPlan,
   planCodexRunner,
   validateAgentRequest,
   validateAgentResult,
@@ -139,6 +140,52 @@ describe('Codex runner planning', () => {
 
     expect(() => planCodexRunner(invalid, { repoRoot: '/tmp/strategy-recipes' })).toThrow(
       'Codex runner cannot execute autonomyMode=enqueue_only',
+    )
+  })
+
+  it('executes planned commands sequentially through an injected executor', async () => {
+    const plan = planCodexRunner(requestFixture, { repoRoot: '/tmp/strategy-recipes' })
+    const seen: string[] = []
+    const execution = await executeCodexRunnerPlan(plan, async (command) => {
+      seen.push(command.command)
+      return {
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        startedAt: '2026-04-30T14:30:00.000Z',
+        completedAt: '2026-04-30T14:30:01.000Z',
+      }
+    })
+
+    expect(seen).toEqual(['git', 'git', 'git', 'codex'])
+    expect(execution.status).toBe('completed')
+    expect(execution.commands).toHaveLength(4)
+  })
+
+  it('stops runner execution on first failing command', async () => {
+    const plan = planCodexRunner(requestFixture, { repoRoot: '/tmp/strategy-recipes' })
+    let count = 0
+    const execution = await executeCodexRunnerPlan(plan, async (command) => {
+      count += 1
+      return {
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: count === 2 ? 1 : 0,
+        stdout: '',
+        stderr: count === 2 ? 'branch exists' : '',
+        startedAt: '2026-04-30T14:30:00.000Z',
+        completedAt: '2026-04-30T14:30:01.000Z',
+      }
+    })
+
+    expect(execution.status).toBe('failed')
+    expect(execution.commands).toHaveLength(2)
+    expect(execution.failedCommand).toBe(
+      'git switch -c factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view origin/main',
     )
   })
 })

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -395,6 +395,51 @@ describe('JsonlAgentQueue', () => {
       'AgentRequest already exists in queue: AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW',
     )
   })
+
+  it('heartbeats active claims and records heartbeat events', async () => {
+    const queue = new JsonlAgentQueue({
+      queueDir: mkdtempSync(join(tmpdir(), 'factory-autonomous-')),
+      actor: 'factory-runner',
+      leaseMs: 60_000,
+      now: fixedClock(),
+    })
+
+    await queue.enqueue(requestFixture)
+    await queue.claimNext()
+    const claim = await queue.heartbeat('AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
+
+    expect(claim.heartbeatAt).toBe('2026-04-30T14:30:00.000Z')
+    expect(claim.leaseExpiresAt).toBe('2026-04-30T14:31:00.000Z')
+    expect((await queue.listEvents()).map((event) => event.type)).toContain('request.heartbeat')
+  })
+
+  it('reclaims expired claims', async () => {
+    let current = new Date('2026-04-30T14:30:00.000Z')
+    const queueDir = mkdtempSync(join(tmpdir(), 'factory-autonomous-'))
+    const queue = new JsonlAgentQueue({
+      queueDir,
+      actor: 'factory-runner-1',
+      leaseMs: 1_000,
+      now: () => current,
+    })
+
+    await queue.enqueue(requestFixture)
+    expect((await queue.claimNext())?.id).toBe('AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
+    expect(await queue.status()).toMatchObject({ pending: 0, claimed: 1 })
+
+    current = new Date('2026-04-30T14:30:02.000Z')
+    const reclaimingQueue = new JsonlAgentQueue({
+      queueDir,
+      actor: 'factory-runner-2',
+      leaseMs: 1_000,
+      now: () => current,
+    })
+
+    expect(await reclaimingQueue.status()).toMatchObject({ pending: 1, claimed: 0 })
+    expect((await reclaimingQueue.claimNext())?.id).toBe('AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
+    expect(await reclaimingQueue.status()).toMatchObject({ pending: 0, claimed: 1 })
+    expect((await reclaimingQueue.listEvents()).filter((event) => event.type === 'request.claimed')).toHaveLength(2)
+  })
 })
 
 describe('single-request scheduler run', () => {

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -11,6 +11,7 @@ import {
   executePullRequestPlan,
   planCodexRunner,
   planPullRequest,
+  runQueueDaemon,
   runSingleAgentRequest,
   validateAgentRequest,
   validateAgentResult,
@@ -545,6 +546,77 @@ describe('single-request scheduler run', () => {
     expect(await queue.status()).toMatchObject({
       total: 1,
       failed: 1,
+    })
+  })
+})
+
+describe('queue daemon', () => {
+  it('claims and runs one queued request through the daemon loop', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'factory-autonomous-'))
+    const queue = new JsonlAgentQueue({
+      queueDir: join(home, 'queue'),
+      actor: 'factory-daemon',
+      now: fixedClock(),
+    })
+    await queue.enqueue(requestFixture)
+
+    const outcome = await runQueueDaemon({
+      queue,
+      repoRoot: '/tmp/strategy-recipes',
+      bundleRoot: join(home, 'bundles'),
+      pollIntervalMs: 0,
+      maxIterations: 1,
+      now: fixedClock(),
+      codexExecutor: async (command) => ({
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        startedAt: '2026-04-30T14:30:00.000Z',
+        completedAt: '2026-04-30T14:30:01.000Z',
+      }),
+      pullRequestExecutor: async (command) => ({
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: 0,
+        stdout: 'https://github.com/Wescome/strategy-recipes/pull/7\n',
+        stderr: '',
+        startedAt: '2026-04-30T14:36:00.000Z',
+        completedAt: '2026-04-30T14:36:01.000Z',
+      }),
+    })
+
+    expect(outcome).toEqual({
+      iterations: 1,
+      completedRuns: 1,
+      stopReason: 'max_iterations',
+    })
+    expect(await queue.status()).toMatchObject({ total: 1, completed: 1 })
+  })
+
+  it('stops daemon loop when stop predicate is set', async () => {
+    const queue = new JsonlAgentQueue({
+      queueDir: mkdtempSync(join(tmpdir(), 'factory-autonomous-')),
+      actor: 'factory-daemon',
+      now: fixedClock(),
+    })
+
+    await expect(
+      runQueueDaemon({
+        queue,
+        repoRoot: '/tmp/strategy-recipes',
+        bundleRoot: '/tmp/bundles',
+        pollIntervalMs: 0,
+        maxIterations: 10,
+        shouldStop: () => true,
+      }),
+    ).resolves.toEqual({
+      iterations: 0,
+      completedRuns: 0,
+      stopReason: 'stop_requested',
     })
   })
 })

--- a/packages/autonomous-scheduler/tsconfig.json
+++ b/packages/autonomous-scheduler/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,18 @@ importers:
         specifier: ^1.4.0
         version: 1.6.1(@types/node@24.12.2)
 
+  packages/autonomous-scheduler:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.39
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^1.4.0
+        version: 1.6.1(@types/node@20.19.39)
+
   packages/candidate-selection:
     dependencies:
       '@factory/schemas':

--- a/specs/reference/SE-GAP-ANALYSIS-TIAGO-GOVERNOR.md
+++ b/specs/reference/SE-GAP-ANALYSIS-TIAGO-GOVERNOR.md
@@ -1,0 +1,880 @@
+# SE Gap Analysis: TIAGO/PAI (Current) vs GovernorAgent (Proposed)
+
+> Systems Engineering Assessment per Sage & Rouse (1999)
+> Supplemented by Patterson (System Boundary), Buede (Functional Decomposition),
+> and TRM (Risk Assessment) frameworks.
+>
+> Analyst: Architect Agent (Systems Engineer role)
+> Date: 2026-04-29
+> Status: Initial Assessment
+
+---
+
+## Executive Summary
+
+The GovernorAgent replaces approximately **20-25%** of TIAGO's functional
+surface area. It replaces the right 20-25% -- the operational monitoring
+and signal-triage loop that currently requires a human session to execute.
+But TIAGO is five systems fused into one runtime. The GovernorAgent only
+addresses one of those five systems (operational governance). The remaining
+four (reasoning, orchestration, memory, communication, development) have
+no proposed replacement and will continue to require human-session-bound
+execution.
+
+This is not a deficiency in the GovernorAgent design. The design is
+appropriately scoped. The gap analysis reveals that the transition is
+not TIAGO-to-GovernorAgent but TIAGO-to-(GovernorAgent + 4 unaddressed
+systems). The GovernorAgent is Phase 1 of a decomposition, not a
+replacement.
+
+---
+
+## 1. System Boundary Analysis (Patterson Ch. 1)
+
+### 1.1 TIAGO/PAI System Boundary
+
+**Runtime boundary:**
+- Process: Claude Code CLI running in macOS Terminal on Wes's MacBook
+- Execution context: Single-threaded conversation loop with tool-calling
+- Compute: Wes's laptop CPU/RAM + Claude API (Anthropic cloud)
+- Network: Outbound HTTP to Cloudflare Workers, GitHub, ArangoDB (via gateway)
+- Filesystem: Full read/write access to `~/Developer/function-factory/`
+- Shell: Full access to `zsh` with `bun`, `vitest`, `wrangler`, `gh`, `git`, `curl`
+
+**Memory boundary:**
+- Persistent: `MEMORY.md` index + per-topic `.md` files in `~/.claude/projects/`
+- Persistent: `CLAUDE.md` (GUV operating rules, constitutional)
+- Persistent: `.agent/memory/` (WORKSPACE.md, LESSONS.md, DECISIONS.md, PREFERENCES.md)
+- Persistent: `.agent/skills/` (PAI Algorithm, domain skills)
+- Ephemeral: Session transcript (conversation context window, ~200K tokens)
+- Ephemeral: Tool call results (git status, curl responses, file contents)
+
+**Authority boundary:**
+- TIAGO CAN: read/write source code, run tests, deploy via wrangler, create PRs,
+  trigger pipelines, approve pipeline gates, spawn sub-agents (Architect, Engineer,
+  SE, QA), adjust hot config, query ArangoDB, save lessons to memory
+- TIAGO CANNOT: make architecture decisions unilaterally (requires Wes's gate),
+  access Cloudflare Worker logs (wrangler tail broken), inspect Queue/DO internals,
+  see pipeline execution in real-time
+- TIAGO MUST: get Wes's approval for architecture gates, follow GUV operating rules,
+  use PAI Algorithm for all responses, spawn Architect review before declaring done
+
+**Temporal boundary:**
+- Session-bound: starts when Wes opens terminal, ends when session closes
+- Context window: ~200K tokens, degrades with conversation length
+- Cross-session: MEMORY.md files bridge sessions but are lossy (summaries, not transcripts)
+- Human-gated: operates only when Wes is available at keyboard
+- Duty cycle: ~4-12 hours/day, 0 hours overnight, 0 hours when Wes is away
+
+**Knowledge boundary:**
+- At session start: MEMORY.md + recent session files (point-in-time snapshots)
+- During session: full codebase access, git history, ArangoDB queries, web research
+- Decay: between sessions, TIAGO forgets conversation context, tool call results,
+  intermediate reasoning. Only what was saved to MEMORY.md survives.
+- Staleness: memory files carry a staleness warning (9-day example in current data)
+
+### 1.2 GovernorAgent System Boundary
+
+**Runtime boundary:**
+- Process: Cloudflare Worker (V8 isolate), triggered by Cron or Queue
+- Execution context: Single function invocation, stateless per cycle
+- Compute: Cloudflare edge CPU (50ms CPU time limit per request, but `ctx.waitUntil`
+  extends to 30s for background work, 120s wall-clock timeout configured)
+- Network: Internal to Cloudflare (Service Bindings, Queue, ArangoDB via HTTP)
+- Filesystem: None (Workers have no filesystem)
+- Shell: None (Workers cannot exec processes)
+
+**Memory boundary:**
+- Persistent: ArangoDB collections (orl_telemetry, specs_signals, memory_curated,
+  orientation_assessments, completion_ledgers, hot_config, execution_artifacts)
+- Ephemeral: Single LLM context window per cycle (~16K tokens input, ~8K output)
+- No session transcript: each cycle is independent, no conversation memory
+- No cross-cycle state: all state lives in ArangoDB, no in-process accumulation
+
+**Authority boundary:**
+- GovernorAgent CAN: read ArangoDB (8 parallel queries), trigger pipelines
+  (via Workflow.create), approve pipeline gates (via Workflow.sendEvent),
+  file GitHub issues (via REST API), archive/deduplicate signals (ArangoDB
+  mutations), adjust hot_config within safe ranges, write governance
+  telemetry and assessments to ArangoDB
+- GovernorAgent CANNOT: read source code, write source code, modify agent
+  prompts, change routing config, deploy Workers, make architecture decisions,
+  suppress escalations, exceed budget thresholds, run tests, access secrets
+  in prompt context
+- GovernorAgent MUST: validate all actions through deterministic criteria gates
+  before execution (LLM proposes, code validates), escalate per hard-coded
+  criteria, stay within 5 pipelines/cycle and 3 approvals/cycle budget
+
+**Temporal boundary:**
+- Cron-triggered: every 15 minutes, 96 cycles/day, 24/7/365
+- Cycle duration: max 120 seconds per cycle
+- No session concept: each cycle is a fresh invocation with no memory of prior cycles
+  except what is in ArangoDB
+- Lookback window: 7-day telemetry, 2-day pipelines, 30 pending signals, 20 feedback
+  signals, 20 curated lessons, 10 assessments, 10 ledgers
+- Always-on: no human availability dependency
+
+**Knowledge boundary:**
+- At cycle start: only what the 8 AQL queries return from ArangoDB
+- During cycle: single LLM invocation with formatted context (no tool use, no
+  iterative reasoning, no follow-up questions)
+- No codebase knowledge: cannot read source files, cannot understand code structure,
+  cannot correlate telemetry to specific code paths
+- No conversation context: cannot discuss findings with Wes, cannot receive corrections,
+  cannot iteratively refine understanding
+
+### 1.3 Boundary Comparison Summary
+
+| Dimension | TIAGO | GovernorAgent |
+|-----------|-------|---------------|
+| Runtime | MacBook terminal process | CF Worker isolate |
+| Duration | Hours (session-bound) | Seconds (cycle-bound) |
+| Availability | When Wes is present | 24/7 |
+| Filesystem | Full read/write | None |
+| Shell access | Full (bun, git, wrangler, gh) | None |
+| Memory persistence | MEMORY.md files | ArangoDB |
+| Context window | ~200K tokens | ~16K tokens |
+| LLM interaction | Multi-turn conversation | Single invocation |
+| Human in loop | Continuous (Wes at keyboard) | None (escalation via GitHub issues) |
+| Sub-agent spawning | Yes (Architect, Engineer, SE, QA) | No |
+| Observability of Factory | HTTP-only (gateway queries) | Internal (same CF environment) |
+| Source code access | Full | None |
+| Deployment capability | Yes (wrangler deploy) | No |
+
+---
+
+## 2. Functional Decomposition (Buede Ch. 25)
+
+### 2.1 TIAGO's Actual Functions
+
+Decomposed from CLAUDE.md (GUV operating rules), PAI SKILL.md (Algorithm),
+ARCHITECTURE-TIAGO-FACTORY-INTERACTION.md (interaction patterns), and
+MEMORY.md (accumulated session patterns).
+
+#### F1: Session Initialization
+- Read MEMORY.md index
+- Read latest session handoff files
+- Debrief Wes on last session results
+- Surface time-sensitive items (deadlines, aging decisions)
+- Cold start recovery (read memory/ and vault/ if context missing)
+
+#### F2: Situation Observation
+- Check git status (uncommitted changes, branch state)
+- Query ArangoDB via gateway (pipeline results, signal backlog, telemetry)
+- Check GitHub (open PRs, issues, CI status)
+- Read Factory health endpoint
+- Correlate observations into situation awareness
+
+#### F3: Orientation & Analysis
+- Analyze situation against known patterns (LESSONS.md, DECISIONS.md)
+- Identify gaps between expected and actual state
+- Cross-reference codebase against specs
+- Produce typed assessments (gap analyses, conflict registers, SE evaluations)
+- Apply PAI Algorithm (7 phases: Observe, Think, Plan, Build, Execute, Verify, Learn)
+- Run thinking tools (Council, RedTeam, FirstPrinciples, Science, BeCreative)
+
+#### F4: Decision Presentation
+- Present options to Wes with tradeoffs
+- Frame decisions in architect's language (not implementation detail)
+- Wait for Wes's "go" on architecture gates
+- Receive and incorporate corrections ("not that, do this")
+
+#### F5: Agent Orchestration
+- Spawn Architect agent (design review, architecture analysis)
+- Spawn Engineer agent (code implementation, test writing)
+- Spawn SE agent (systems engineering analysis)
+- Spawn QA agent (testing, verification)
+- Spawn Researcher agents (web research, content analysis)
+- Coordinate parallel agent swarms (SWARM IS DEFAULT)
+- Synthesize agent outputs into coherent results
+
+#### F6: Development Execution
+- Write/edit TypeScript source code (direct file system access)
+- Run tests (vitest, bun test)
+- Deploy via wrangler (push to Cloudflare)
+- Create GitHub PRs via gh CLI
+- Set secrets via wrangler secret put
+- Trigger Factory pipelines via curl POST
+- Approve pipeline gates via curl POST
+
+#### F7: Verification & Quality
+- Check test results
+- Verify deployment health
+- Confirm Factory pipeline outcomes
+- Run Architect review before declaring done
+- Validate against ISC (Ideal State Criteria) from PAI Algorithm
+- Apply "DONE MEANS DEPLOYED" rule
+
+#### F8: Memory & Learning
+- Save lessons/feedback to MEMORY.md files
+- Update WORKSPACE.md with current state
+- Log actions to AGENT_LEARNINGS.jsonl
+- Update DECISIONS.md for architectural choices
+- Create session handoff files for next session
+- Save substantive analysis to files (COMPOUNDS OVER EPHEMERAL)
+
+#### F9: Communication
+- Natural language conversation with Wes
+- Voice notifications (voice server integration)
+- PAI Algorithm formatted responses (7 phases with ISC)
+- "BE THE BRAIN" -- anticipate what Wes needs to know
+- "BE EXPLICIT ABOUT WHAT YOU NEED" -- lead with blockers
+
+### 2.2 Function-to-GovernorAgent Mapping
+
+| TIAGO Function | GovernorAgent Status | Notes |
+|----------------|---------------------|-------|
+| F1: Session Init | CANNOT DO | No session concept. No MEMORY.md. No debrief. |
+| F2: Situation Observation | DOES DIFFERENTLY | Reads ArangoDB directly (better Factory visibility). Cannot see git, source code, local state. |
+| F3: Orientation & Analysis | DOES DIFFERENTLY (limited) | Single LLM call with 16K context. No multi-turn reasoning. No thinking tools. No PAI Algorithm phases. No codebase cross-reference. |
+| F4: Decision Presentation | CANNOT DO | No human interaction. Escalates via GitHub issues (write-only, no dialogue). |
+| F5: Agent Orchestration | CANNOT DO | No sub-agent spawning. Single-agent, single-invocation design. |
+| F6: Development Execution | CANNOT DO | No filesystem, no shell, no wrangler, no gh. Can trigger pipelines and approve gates (2 of 7 sub-functions). |
+| F7: Verification & Quality | DOES DIFFERENTLY (limited) | Reads pipeline outcomes from ArangoDB. Cannot run tests. Cannot do Architect review. Cannot verify deployment health directly. |
+| F8: Memory & Learning | DOES DIFFERENTLY (limited) | Writes governance assessments and telemetry to ArangoDB. Cannot update MEMORY.md files. Cannot create session handoffs. |
+| F9: Communication | CANNOT DO | No conversation with Wes. GitHub issues are one-directional escalation. |
+
+### 2.3 Coverage Summary
+
+- **Functions GovernorAgent CAN do (with limitations):** F2, F3, F7, F8 (partial)
+- **Functions GovernorAgent CANNOT do at all:** F1, F4, F5, F6 (mostly), F9
+- **Sub-functions GovernorAgent adds (TIAGO cannot):**
+  - Internal Cloudflare observability (Queue state, Worker metrics)
+  - 24/7 automated signal triage
+  - Automated pipeline triggering for safe feedback loops
+  - Automated gate approval for qualifying signals
+  - Continuous operational health assessment
+
+---
+
+## 3. Information Flow Analysis
+
+### 3.1 TIAGO's Information Sources
+
+| Source | Type | Richness | Latency | Authority |
+|--------|------|----------|---------|-----------|
+| Wes's messages | Natural language | Very high (intent, corrections, priorities, domain knowledge) | Real-time | Primary (architect) |
+| Local filesystem | Source code, configs, tests | Complete (all files) | Instant | Primary (ground truth) |
+| Git history | Commits, branches, diffs | Complete history | Instant | Primary |
+| Claude Code tools | Bash, Read, Edit, Write, Agent | Full development toolkit | Seconds | Tool-mediated |
+| HTTP APIs | Gateway, GitHub REST | Structured responses | Seconds | Remote |
+| MEMORY.md files | Accumulated lessons, decisions, preferences | Curated summaries | Instant (local files) | Supporting (lossy) |
+| Skill files | PAI Algorithm, domain skills, protocols | Procedural knowledge | Instant (local files) | Binding (constitutional) |
+| Session transcript | Conversation history | Rich (multi-hour context) | In-memory | Ephemeral |
+
+### 3.2 GovernorAgent's Information Sources
+
+| Source | Type | Richness | Latency | Authority |
+|--------|------|----------|---------|-----------|
+| ArangoDB queries | Telemetry, signals, pipelines, memory, config | Structured, bounded (8 queries, specific LIMIT/FILTER) | Seconds | Primary (Factory state) |
+| Queue messages | Event triggers (feedback-complete) | Minimal (trigger type + timestamp) | Instant (internal) | Primary |
+| Cron schedule | Time triggers | None (time only) | 15-minute intervals | Trigger |
+| LLM (kimi-k2.6) | Assessment reasoning | Single-shot, 16K input | Seconds | Derived (assessment) |
+
+### 3.3 Information TIAGO Has That GovernorAgent Will NOT Have
+
+| Information | Impact of Loss | Severity |
+|-------------|----------------|----------|
+| **Wes's intent in natural language** | Cannot understand WHY something should be done, only WHAT telemetry shows. Cannot receive strategic direction. Cannot incorporate business context, priorities, or "actually, I meant X not Y." | CRITICAL |
+| **Source code** | Cannot correlate telemetry failures to specific code paths. Cannot understand what a pipeline failure means at the code level. Cannot diagnose root causes that require reading implementation. | CRITICAL |
+| **Git history and diffs** | Cannot see what changed between deployments. Cannot correlate regressions to specific commits. | HIGH |
+| **Test results** | Cannot run tests to validate hypotheses. Cannot confirm whether a fix actually works before triggering retry. | HIGH |
+| **Shell tooling** | Cannot deploy, cannot run arbitrary diagnostics, cannot use gh CLI for rich GitHub interactions. | HIGH |
+| **Sub-agent perspectives** | Cannot get Architect review of its own decisions. Cannot get SE analysis of systemic issues. Cannot get specialized domain reasoning. | HIGH |
+| **Multi-turn reasoning** | Limited to single LLM invocation. Cannot iteratively refine understanding. Cannot say "wait, that doesn't make sense, let me re-examine." | MEDIUM |
+| **Session context** | Each cycle starts fresh. Cannot carry forward observations from 15 minutes ago unless they were written to ArangoDB. Pattern recognition across cycles is limited to what AQL queries return. | MEDIUM |
+| **Correction feedback loop** | When the GovernorAgent makes a wrong assessment, there is no mechanism for Wes to say "no, that's wrong because X." The GovernorAgent will repeat the same mistake next cycle. | CRITICAL |
+| **PAI Algorithm** | No 7-phase reasoning structure. No ISC criteria. No hill-climbing. No thinking tools. The GovernorAgent's reasoning is unstructured single-shot. | MEDIUM |
+
+### 3.4 Information GovernorAgent Has That TIAGO Does NOT Have
+
+| Information | Benefit | Significance |
+|-------------|---------|--------------|
+| **Internal Cloudflare observability** | Can potentially see Worker metrics, Queue depth, DO state that TIAGO cannot access via HTTP | HIGH |
+| **Continuous 24/7 coverage** | Sees signals as they arrive, not hours later when Wes opens a session | HIGH |
+| **Same-environment execution** | No network hop to query ArangoDB; direct Cloudflare internal access | MEDIUM |
+| **Structured governance telemetry** | Produces its own telemetry (governance cycles, decisions, assessments) that compounds over time | MEDIUM |
+
+### 3.5 Net Information Position
+
+TIAGO has access to approximately 10 rich information channels.
+GovernorAgent has access to 4 channels, all structured/database-mediated.
+
+The GovernorAgent trades information richness for temporal coverage.
+TIAGO sees deeply but intermittently. GovernorAgent sees narrowly but
+continuously. Neither alone provides complete governance.
+
+---
+
+## 4. Capability Gap Matrix
+
+| # | TIAGO Capability | GovernorAgent Equivalent | Gap | Impact | Mitigation |
+|---|-----------------|------------------------|-----|--------|------------|
+| 1 | Read source code (full repo) | Cannot read source | TOTAL | Cannot diagnose code-level root causes. Cannot verify implementations match specs. | GovernorAgent escalates code-level issues. TIAGO handles in next session. |
+| 2 | Write/edit source code | Cannot write code | TOTAL (by design) | Cannot fix anything. Cannot implement anything. | GovernorAgent's scope excludes code. Correct design boundary. |
+| 3 | Run tests (vitest, bun test) | Cannot run tests | TOTAL | Cannot validate fixes. Cannot regression-test before re-triggering. | Tests run inside pipeline (CoderAgent/TesterAgent). GovernorAgent observes results via ArangoDB. |
+| 4 | Deploy via wrangler | Cannot deploy | TOTAL (by design) | Cannot push code changes to Cloudflare. | Deployment requires human session. Correct governance constraint. |
+| 5 | Spawn sub-agents (Architect, Engineer, SE, QA) | Single-agent, single-invocation | TOTAL | No multi-perspective reasoning. No specialized domain analysis. No independent review of its own decisions. | Phase 3 of evolution path adds multi-agent delegation. Currently absent. |
+| 6 | Read Wes's intent in natural language | None | TOTAL | Cannot understand strategic direction. Makes decisions based only on telemetry, not intent. | GovernorAgent operates within narrow deterministic criteria. Strategic intent stays with TIAGO. |
+| 7 | Respond to corrections ("not that, do this") | None | TOTAL | Cannot learn from real-time feedback. Will repeat mistakes until criteria are manually adjusted. | Human overrides via hot_config or criteria code changes. Slow feedback loop. |
+| 8 | Create GitHub PRs via gh CLI | Escalation via GitHub REST (issues only, not PRs) | PARTIAL | Cannot create PRs for fixes. Can create issues for human attention. PR creation is handled by Factory's feedback pipeline separately. | Factory already creates PRs autonomously. GovernorAgent creates issues for escalation. Different tools for different purposes. |
+| 9 | Maintain session context (hours) | 16K tokens, single invocation | MAJOR | Cannot build understanding over time within a session. Cannot cross-reference earlier observations in same work session. | Each cycle is 120 seconds. Understanding is ArangoDB-mediated across cycles, not conversation-mediated. |
+| 10 | Save lessons/feedback to MEMORY.md | Writes assessments to ArangoDB orientation_assessments | DIFFERENT | Knowledge compounds in ArangoDB, not in MEMORY.md. TIAGO and GovernorAgent maintain separate knowledge stores. | Bridge needed: TIAGO reads GovernorAgent's assessments from ArangoDB. GovernorAgent reads memory_curated. Two-way but lossy. |
+| 11 | Apply PAI Algorithm (7 phases, ISC, thinking tools) | Single-shot LLM with system prompt | TOTAL | No structured reasoning methodology. No verifiable criteria. No hill-climbing toward ideal state. | GovernorAgent's system prompt provides governance-specific structure. Not PAI but not unstructured. Fit for purpose (operational triage, not deep reasoning). |
+| 12 | Multi-turn iterative refinement | Single LLM call | TOTAL | Cannot say "wait, let me reconsider." Cannot explore alternative interpretations. | Cycle brevity (120s) limits but focuses. Complex reasoning escalates to TIAGO. |
+| 13 | Arbitrary HTTP diagnostics | ArangoDB queries only | MAJOR | Cannot curl arbitrary endpoints. Cannot test connectivity. Cannot probe edge cases. | GovernorAgent's observability is ArangoDB-mediated. Add new queries for new observability needs. |
+| 14 | 24/7 availability | 24/7 by default | TIAGO LACKS | TIAGO is offline 12-20 hours/day. Signals age. Feedback loops stall. | GovernorAgent solves this completely. Primary value proposition. |
+| 15 | Internal CF observability | Same environment as Factory | TIAGO LACKS | TIAGO cannot see Worker logs, Queue state, DO internals. | GovernorAgent's AQL queries provide structured visibility. Not full log access but better than TIAGO's HTTP-only view. |
+
+---
+
+## 5. Risk Assessment (TRM Six Questions)
+
+### Risk 1: Loss of Natural Language Understanding of Wes's Intent
+
+**What can go wrong?** The GovernorAgent operates without understanding
+Wes's priorities, strategic direction, or contextual reasoning. It makes
+operational decisions based purely on telemetry patterns and codified
+criteria, missing the "why" behind Wes's architectural choices.
+
+**Likelihood:** Certain (by design -- the GovernorAgent has no human
+interaction channel).
+
+**Impact:** MEDIUM. Mitigated because the GovernorAgent's action space is
+constrained to operational triage (trigger safe retries, archive stale
+signals, escalate unknowns). It is not making strategic decisions. When
+something requires intent-understanding, it escalates.
+
+**Mitigation:** Deterministic criteria gates prevent the GovernorAgent from
+making intent-dependent decisions. Hot_config allows Wes to adjust
+GovernorAgent behavior between sessions. Escalation via GitHub issues
+brings Wes into the loop for anything non-routine.
+
+**Residual risk:** LOW. The GovernorAgent may over-escalate (false
+positives) because it cannot distinguish "Wes would obviously approve
+this" from "Wes needs to see this." This is the correct failure mode --
+fail-safe rather than fail-dangerous.
+
+---
+
+### Risk 2: Loss of Codebase Access
+
+**What can go wrong?** The GovernorAgent detects telemetry anomalies but
+cannot correlate them to specific code paths. When ORL success rates drop,
+it cannot read the code to understand whether the problem is a prompt
+issue, a schema issue, a model issue, or a code bug.
+
+**Likelihood:** HIGH (inevitable for code-level failures).
+
+**Impact:** MEDIUM. The GovernorAgent's response to code-level issues is
+always "escalate." It does not attempt code-level diagnosis. The impact
+is diagnostic delay, not incorrect action.
+
+**Mitigation:** The GovernorAgent's `diagnose_failure` action writes
+diagnostic assessments to ArangoDB with available evidence. When TIAGO
+starts the next session, it can read these assessments and begin
+code-level investigation with context already gathered.
+
+**Residual risk:** MEDIUM. The diagnostic delay (up to hours) means
+code-level issues compound. A broken pipeline keeps creating failing
+runs until Wes investigates. The feedback loop depth limit (max 3) and
+cooldown (30 min) prevent runaway, but the underlying issue persists.
+
+---
+
+### Risk 3: Loss of Sub-Agent Orchestration
+
+**What can go wrong?** TIAGO coordinates multiple specialized agents
+(Architect, Engineer, SE, QA) in parallel swarms. The GovernorAgent
+operates as a single agent with a single LLM invocation. It cannot get
+a second opinion, cannot validate its own reasoning, and cannot delegate
+diagnostic sub-tasks.
+
+**Likelihood:** Certain (by design -- Phase 1 is single-agent).
+
+**Impact:** LOW for operational triage (the GovernorAgent's primary job).
+HIGH for diagnostic tasks (where multiple perspectives would help).
+
+**Mitigation:** Phase 3 of the evolution path adds multi-agent delegation
+(DriftDiagnosisAgent, ContractHealthAgent as sub-agents of Governor).
+Currently, the GovernorAgent's decisions are validated by deterministic
+criteria gates, not by sub-agent review.
+
+**Residual risk:** MEDIUM. Single-agent reasoning is more prone to
+systematic bias. The deterministic gates catch criteria-violating
+decisions but do not catch reasoning errors within criteria bounds.
+
+---
+
+### Risk 4: Loss of Correction Feedback Loop
+
+**What can go wrong?** When TIAGO makes a mistake, Wes says "no, do X
+instead" and TIAGO adjusts immediately. The GovernorAgent has no such
+mechanism. If it misjudges a signal's severity, over-escalates, or
+under-escalates, the error repeats every 15 minutes until someone
+changes the code or criteria.
+
+**Likelihood:** HIGH (GovernorAgent will make wrong assessments; all
+LLM-based systems do).
+
+**Impact:** MEDIUM for false positives (noisy GitHub issues that Wes
+ignores). HIGH for false negatives (missed escalations where GovernorAgent
+incorrectly classifies something as safe).
+
+**Mitigation:** The evolution_contract tracks human_override_frequency.
+If Wes frequently overrides GovernorAgent decisions, this becomes an
+evolution signal. Phase 4 (Self-Tuning) allows threshold adjustment based
+on override patterns. Currently, corrections require code changes to
+criteria functions.
+
+**Residual risk:** HIGH. The correction loop is orders of magnitude
+slower than TIAGO's real-time correction. TIAGO adjusts in seconds.
+GovernorAgent adjusts via code deploy (hours to days). This is the most
+significant operational risk.
+
+---
+
+### Risk 5: Loss of Session Context
+
+**What can go wrong?** TIAGO builds understanding over a multi-hour
+session. It sees a failing test, reads the code, tries a fix, sees the
+fix fail differently, and eventually converges on the root cause. The
+GovernorAgent sees telemetry snapshots every 15 minutes with no memory
+of what it concluded 15 minutes ago (except what it wrote to ArangoDB).
+
+**Likelihood:** Certain.
+
+**Impact:** LOW for routine operations (each governance cycle is
+independent by design). MEDIUM for trend analysis (the GovernorAgent
+relies on AQL aggregation, not conversational memory, for trends).
+
+**Mitigation:** The GovernorAgent's 7-day lookback queries provide
+aggregate trend data. Individual cycle assessments are persisted to
+orientation_assessments, creating a queryable history. The GovernorAgent
+does not need conversational memory for its operational scope.
+
+**Residual risk:** LOW. This is a design choice, not a gap. The
+GovernorAgent is not trying to be a conversational partner. Its
+stateless-per-cycle design is appropriate for its scope.
+
+---
+
+### Risk 6: 24/7 Availability vs Quality Trade-off
+
+**What can go wrong?** The GovernorAgent runs 96 times per day but with
+much less cognitive depth per cycle than TIAGO brings to a single session.
+Quantity of governance cycles may not compensate for quality of governance
+reasoning. The Factory gets continuous but shallow oversight instead of
+intermittent but deep oversight.
+
+**Likelihood:** Certain (this is the fundamental trade-off of the design).
+
+**Impact:** MEDIUM. The GovernorAgent's quality floor is set by
+deterministic criteria gates, not by LLM reasoning quality. Bad
+LLM reasoning leads to "no_action" (safe) or "escalate_to_human" (safe),
+not to incorrect autonomous action.
+
+**Mitigation:** The deterministic action gate (Section 10.4 of the design)
+is the critical safety mechanism. The LLM proposes, the code validates.
+This means LLM quality affects diagnostic accuracy and assessment
+quality but not action safety.
+
+**Residual risk:** LOW for safety. MEDIUM for effectiveness (the
+GovernorAgent may miss opportunities that TIAGO would have caught through
+deeper reasoning). Over time, as memory_curated accumulates patterns,
+the GovernorAgent's context improves.
+
+---
+
+## 6. Architecture Recommendations
+
+### 6.1 What MUST Stay with TIAGO (Irreplaceable Capabilities)
+
+1. **Architecture decision-making** -- requires Wes's gate, natural
+   language dialogue, multi-perspective analysis (Council, Architect agent).
+   No automated replacement exists.
+
+2. **Code-level root cause diagnosis** -- requires reading source code,
+   understanding implementation, correlating telemetry to code paths.
+   GovernorAgent cannot do this.
+
+3. **Development execution** -- writing code, running tests, deploying.
+   The GovernorAgent is correctly excluded from this.
+
+4. **Strategic prioritization** -- deciding WHAT to build next, in what
+   order, with what trade-offs. Requires Wes's business context and
+   architectural vision.
+
+5. **Correction and learning** -- real-time feedback ("not that, do this")
+   that adjusts TIAGO's behavior within a session. No GovernorAgent
+   equivalent exists.
+
+6. **Multi-agent orchestration for complex tasks** -- spawning Architect +
+   Engineer + QA swarms for implementation work. GovernorAgent is
+   single-agent.
+
+7. **PAI Algorithm execution** -- the 7-phase structured reasoning
+   methodology with ISC criteria, thinking tools, and capability
+   selection. This is TIAGO's cognitive operating system and has no
+   GovernorAgent equivalent.
+
+### 6.2 What CAN Move to GovernorAgent (Operational Tasks)
+
+1. **Signal triage** -- reviewing pending signals, prioritizing by
+   severity/age, deduplicating, archiving stale signals. This is
+   GovernorAgent's primary function and it does this well.
+
+2. **Safe pipeline triggering** -- re-triggering feedback-generated
+   signals that meet auto-trigger criteria. This is the 24/7 value
+   proposition.
+
+3. **Safe gate approval** -- auto-approving qualifying signals at
+   architect-approval gates. Eliminates the bottleneck of Wes being
+   unavailable.
+
+4. **Operational health monitoring** -- continuous assessment of ORL
+   success rates, pipeline failure rates, stale signal counts. Better
+   than TIAGO's periodic manual checks.
+
+5. **Escalation** -- detecting conditions that require human attention
+   and filing GitHub issues with evidence. Replaces TIAGO's manual
+   observation of problems.
+
+6. **Governance telemetry** -- producing its own observability data
+   (cycle results, assessments, metrics snapshots) that TIAGO can
+   review in the next session.
+
+### 6.3 What Needs a NEW System (Neither TIAGO nor GovernorAgent)
+
+1. **Diagnostic Bridge** -- a mechanism for the GovernorAgent to
+   request deeper analysis from a more capable agent when it detects
+   anomalies it cannot diagnose. This is Phase 3 of the evolution path
+   (Multi-Agent Governor) but is not designed yet. The current design
+   has no intermediate step between "single-shot LLM assessment" and
+   "escalate to human via GitHub issue."
+
+2. **Bi-directional Memory Synchronization** -- TIAGO writes to MEMORY.md
+   files, GovernorAgent writes to ArangoDB. Neither reads the other's
+   primary store. A sync mechanism is needed so:
+   - GovernorAgent's assessments are available as TIAGO's session context
+   - TIAGO's lessons and corrections update GovernorAgent's criteria
+
+3. **Correction Loop** -- when Wes overrides a GovernorAgent decision
+   (e.g., approves something GovernorAgent escalated, or rejects
+   something GovernorAgent triggered), that override must feed back into
+   GovernorAgent's criteria. Currently, this requires a code change.
+   Phase 4 (Self-Tuning) addresses this but is not yet designed.
+
+4. **Dashboard / Reporting** -- TIAGO's "debrief Wes on last session"
+   function has no GovernorAgent equivalent. Wes currently learns what
+   happened overnight by reading TIAGO's debrief. With GovernorAgent
+   running 24/7, there should be a summary mechanism (daily digest,
+   dashboard, or structured report) that Wes can review without starting
+   a TIAGO session.
+
+### 6.4 Right Division of Labor in Steady State
+
+```
+Wes (Architect)
+  |
+  |-- Architectural decisions, strategic priorities, business context
+  |
+  v
+TIAGO (Governor-in-Chief, session-bound)
+  |
+  |-- Deep reasoning (PAI Algorithm, multi-agent, multi-turn)
+  |-- Code-level diagnosis and implementation orchestration
+  |-- MEMORY.md maintenance and session continuity
+  |-- Reads GovernorAgent's overnight assessments at session start
+  |-- Adjusts GovernorAgent criteria based on accumulated corrections
+  |-- Handles all GovernorAgent escalations that require code/architecture
+  |
+  v
+GovernorAgent (Operations Officer, 24/7)
+  |
+  |-- Continuous signal triage and operational health monitoring
+  |-- Auto-trigger safe feedback pipeline retries
+  |-- Auto-approve qualifying gate signals
+  |-- Escalate anomalies via GitHub issues
+  |-- Produce governance telemetry for TIAGO's next session
+  |-- Archive stale signals, deduplicate, manage backlog hygiene
+  |
+  v
+Factory Pipeline (Autonomous Execution)
+  |
+  |-- Multi-stage pipeline execution (LLM calls, synthesis, testing)
+  |-- Feedback signal generation
+  |-- PR creation
+  |-- Memory curation
+```
+
+This is a **three-tier governance model**:
+- **Wes** for architectural authority
+- **TIAGO** for cognitive reasoning and development orchestration
+- **GovernorAgent** for 24/7 operational automation
+
+The GovernorAgent does NOT replace TIAGO. It sits below TIAGO in the
+authority hierarchy, handling the operational tasks that do not require
+TIAGO's cognitive depth but do require continuous execution.
+
+---
+
+## 7. The Hard Question
+
+### What TIAGO Actually Is
+
+TIAGO is not one system. TIAGO is five systems fused into a single
+runtime by the constraint of running inside Claude Code:
+
+| System | Function | % of TIAGO's Value |
+|--------|----------|-------------------|
+| **Reasoning System** | PAI Algorithm, 7 phases, ISC criteria, thinking tools (Council, RedTeam, FirstPrinciples), multi-turn iterative refinement | ~30% |
+| **Orchestration System** | Spawn Architect, Engineer, SE, QA agents in parallel swarms. Coordinate, synthesize, gate. | ~25% |
+| **Memory System** | MEMORY.md read/write, session continuity, lesson extraction, correction accumulation, cold start recovery | ~15% |
+| **Communication System** | Natural language dialogue with Wes, voice notifications, intent clarification, correction reception, decision presentation | ~15% |
+| **Development System** | Source code read/write, test execution, wrangler deploy, gh CLI, git operations, shell tooling | ~15% |
+
+### What the GovernorAgent Replaces
+
+The GovernorAgent replaces **a subset of the Orchestration System's
+operational monitoring function**. Specifically:
+
+- Signal triage (from Orchestration)
+- Pipeline triggering (from Orchestration)
+- Gate approval (from Orchestration)
+- Health monitoring (from Orchestration)
+- Escalation (from Orchestration + Communication, but write-only)
+
+This is approximately **20-25%** of what TIAGO does, and only the
+operational automation slice.
+
+### What Happens to the Other 4 Systems
+
+| System | Post-GovernorAgent State | Status |
+|--------|-------------------------|--------|
+| **Reasoning System** | Stays with TIAGO. No proposed replacement. PAI Algorithm, thinking tools, multi-turn reasoning remain session-bound. | UNCHANGED |
+| **Orchestration System** | Split. Operational monitoring moves to GovernorAgent. Strategic orchestration (agent spawning, development coordination) stays with TIAGO. | PARTIALLY ADDRESSED |
+| **Memory System** | Stays with TIAGO. GovernorAgent has its own ArangoDB-based memory but does not replace MEMORY.md. A synchronization gap exists. | UNCHANGED (gap created) |
+| **Communication System** | Stays with TIAGO. GovernorAgent has write-only escalation (GitHub issues) but no dialogue capability. Wes must start a TIAGO session to discuss GovernorAgent findings. | UNCHANGED |
+| **Development System** | Stays with TIAGO entirely. GovernorAgent cannot read code, write code, run tests, or deploy. | UNCHANGED |
+
+### The Architectural Truth
+
+The GovernorAgent is not a TIAGO replacement. It is a **TIAGO
+augmentation** that extends TIAGO's availability from ~8 hours/day to
+24 hours/day for a narrow operational scope.
+
+In steady state, the system is TIAGO + GovernorAgent, not GovernorAgent
+instead of TIAGO. TIAGO remains the primary governance system. The
+GovernorAgent keeps the lights on between TIAGO sessions.
+
+This is the correct framing:
+
+- **Without GovernorAgent:** Factory runs when Wes works. Signals age
+  overnight. Feedback loops stall for 12-16 hours. TIAGO spends first
+  30 minutes of each session triaging overnight backlog.
+
+- **With GovernorAgent:** Factory runs continuously. Safe retries happen
+  automatically. Stale signals get archived. Wes wakes up to a clean
+  backlog and a governance assessment. TIAGO can focus on deep work
+  instead of operational triage.
+
+The GovernorAgent's value is not in replacing TIAGO's intelligence.
+It is in **eliminating the overnight gap** that makes the Factory
+intermittent.
+
+---
+
+## 8. Formal Assessment: Transition Readiness
+
+### 8.1 Readiness Verdict
+
+**The GovernorAgent design is ready for implementation with the
+following understanding:**
+
+1. It replaces 20-25% of TIAGO's functional surface.
+2. It replaces the correct 20-25% -- the part that suffers most from
+   being session-bound.
+3. It does NOT replace TIAGO. TIAGO continues as the primary governance
+   system.
+4. The deterministic action gate is the critical safety mechanism and
+   is well-designed.
+5. The escalation criteria are conservative (fail-safe).
+
+### 8.2 Pre-Implementation Requirements
+
+1. **Memory Bridge Design:** Before GovernorAgent goes live, define how
+   TIAGO reads GovernorAgent assessments at session start. Currently,
+   TIAGO's session init reads MEMORY.md. It should also read recent
+   `orientation_assessments` from ArangoDB via gateway.
+
+2. **Correction Pipeline Design:** Define how Wes's overrides of
+   GovernorAgent decisions feed back into criteria. Phase 4 addresses
+   this but is not designed. At minimum, a manual process should be
+   documented (Wes adjusts hot_config or criteria code).
+
+3. **Escalation Channel Validation:** Verify that GitHub issue creation
+   via the GovernorAgent's `GITHUB_TOKEN` is correctly scoped. The
+   Factory already has its own GITHUB_TOKEN for PR creation. GovernorAgent
+   may need a separate token or verified permissions for issue creation.
+
+4. **Observability Baseline:** Before GovernorAgent goes live, establish
+   baseline metrics for the governance health indicators it will monitor
+   (ORL success rates, pipeline failure rates, signal backlog depth).
+   Without baselines, the GovernorAgent cannot detect degradation.
+
+### 8.3 Post-Implementation Validation
+
+1. **Dry-run period:** Run GovernorAgent with `dryRun: true` for 1-2
+   weeks. It produces assessments and decisions but does not execute
+   them. TIAGO reviews the decisions to validate criteria correctness.
+
+2. **Escalation calibration:** Track false_escalation_rate and
+   missed_escalation_rate. If false escalation exceeds 10%, widen
+   auto-action criteria. If missed escalation occurs, narrow them.
+
+3. **Overnight value test:** After 1 week of live operation, compare
+   Wes's first-session-of-day experience. Is the backlog smaller?
+   Are assessments useful? Is TIAGO spending less time on triage?
+
+---
+
+## 9. Recommendations Summary
+
+| Priority | Recommendation | Rationale |
+|----------|---------------|-----------|
+| P0 | Implement GovernorAgent as designed | Solves the 24/7 availability gap for operational triage |
+| P0 | Design the Memory Bridge (TIAGO reads GovernorAgent assessments) | Without this, the two governance systems are disconnected |
+| P1 | Establish observability baselines before go-live | GovernorAgent needs reference points to detect degradation |
+| P1 | Plan dry-run period (1-2 weeks, dryRun=true) | Validate criteria before autonomous execution |
+| P2 | Design correction pipeline (Wes override -> criteria adjustment) | Currently requires code deploy; needs faster feedback loop |
+| P2 | Design daily digest (GovernorAgent summary for Wes) | Replace TIAGO's debrief function for overnight activity |
+| P3 | Design Phase 3 multi-agent diagnostic delegation | Single-agent reasoning is a known limitation for complex diagnosis |
+| P3 | Design Phase 4 self-tuning threshold adjustment | Addresses the correction feedback loop gap systematically |
+
+---
+
+## 10. Decision Algebra Alignment
+
+Mapping this assessment to the Ontology's Decision Algebra:
+
+```
+D = <I, C, P, E, A, X, O, J, T>
+
+I (Intent)         = Determine whether GovernorAgent adequately replaces
+                     TIAGO's governance functions
+C (Context)        = Full TIAGO/PAI system docs, GovernorAgent design,
+                     Orientation Ontology, ARCHITECTURE-TIAGO-FACTORY-INTERACTION
+P (Policy)         = SE methodology (Sage & Rouse), AGENTS.md role boundaries,
+                     GUV operating rules, PAI constitutional principles
+E (Evidence)       = Functional decomposition (9 TIAGO functions mapped),
+                     Capability Gap Matrix (15 capabilities compared),
+                     Information Flow Analysis (10 TIAGO sources vs 4 GovernorAgent)
+A (Authority)      = Architect Agent (SE role), pending Wes's review
+X (Action)         = SE Gap Analysis document with recommendations
+O (Outcome)        = GovernorAgent replaces 20-25% of TIAGO, correct scope,
+                     proceed with implementation + 4 identified gaps to address
+J (Justification)  = GovernorAgent solves the right problem (24/7 availability)
+                     without overreaching into capabilities it cannot safely handle
+T (Time)           = 2026-04-29, bootstrap phase, pre-implementation assessment
+```
+
+---
+
+## Appendix A: TIAGO's Five Systems Decomposition
+
+```
+TIAGO (Claude Code on Wes's MacBook)
+|
++-- REASONING SYSTEM
+|   |-- PAI Algorithm (7 phases)
+|   |-- ISC Criteria (hill-climbing)
+|   |-- Thinking Tools (Council, RedTeam, FirstPrinciples, Science, BeCreative)
+|   |-- Multi-turn iterative refinement
+|   |-- ~200K token context window
+|   +-- Cross-domain pattern matching
+|
++-- ORCHESTRATION SYSTEM
+|   |-- Agent spawning (Architect, Engineer, SE, QA, Researcher)
+|   |-- Parallel swarm coordination (SWARM IS DEFAULT)
+|   |-- Pipeline triggering (curl POST /pipeline)
+|   |-- Gate approval (curl POST /approve/:id)
+|   |-- Result monitoring (curl GET /pipeline/:id)
+|   +-- Backlog management (signal triage, dedup, archive)
+|       ^
+|       |-- THIS is what GovernorAgent replaces (partially)
+|
++-- MEMORY SYSTEM
+|   |-- MEMORY.md index + per-topic files
+|   |-- WORKSPACE.md (current task state)
+|   |-- LESSONS.md (accumulated patterns)
+|   |-- DECISIONS.md (architectural choices)
+|   |-- PREFERENCES.md (stable conventions)
+|   |-- Session handoff files
+|   |-- AGENT_LEARNINGS.jsonl (action log)
+|   +-- COMPOUNDS OVER EPHEMERAL (save substantive analysis)
+|
++-- COMMUNICATION SYSTEM
+|   |-- Natural language dialogue with Wes
+|   |-- Voice notifications
+|   |-- PAI-formatted responses
+|   |-- BE THE BRAIN (anticipate needs)
+|   |-- BE EXPLICIT ABOUT WHAT YOU NEED (lead with blockers)
+|   |-- Decision presentation (options, tradeoffs, recommendations)
+|   +-- Correction reception ("not that, do this")
+|
++-- DEVELOPMENT SYSTEM
+    |-- Source code read/write (full filesystem)
+    |-- Test execution (vitest, bun test)
+    |-- Deployment (wrangler deploy)
+    |-- GitHub operations (gh CLI)
+    |-- Git operations (commit, branch, diff)
+    |-- Secret management (wrangler secret put)
+    +-- Shell tooling (arbitrary bun/node/curl commands)
+```
+
+---
+
+## Appendix B: Information Flow Diagram (Steady State)
+
+```
+Wes (Architect)
+  |
+  | Natural language intent, corrections, architecture gates
+  |
+  v
+TIAGO (Governor-in-Chief)
+  |
+  |-- Reads GovernorAgent assessments from ArangoDB (session start)
+  |-- Adjusts GovernorAgent criteria (code changes, hot_config)
+  |-- Handles GovernorAgent escalations (GitHub issues)
+  |-- Deep diagnosis + implementation orchestration
+  |-- Writes MEMORY.md (session state, lessons, decisions)
+  |
+  v                                        v
+Development                            GovernorAgent (24/7 Operations)
+  |                                        |
+  |-- Source code changes                  |-- Reads ArangoDB (8 queries/cycle)
+  |-- Test execution                       |-- Signal triage + dedup + archive
+  |-- wrangler deploy                      |-- Auto-trigger safe pipelines
+  |-- gh pr create                         |-- Auto-approve qualifying gates
+  |-- git commit                           |-- Escalate via GitHub issues
+  |                                        |-- Write governance telemetry
+  v                                        |
+Factory Pipeline                           |
+  |                                        |
+  |-- Autonomous execution                 |
+  |-- ArangoDB writes                <-----|-- Reads pipeline results
+  |-- Feedback signals               ----->|-- Reads pending signals
+  |-- PR generation                        |
+  |-- Memory curation                ----->|-- Reads curated memory
+  v
+ArangoDB (Shared State)
+```
+
+---
+
+*This assessment was produced by the Architect Agent in the Systems Engineer
+role. All findings are based on analysis of the authoritative source
+documents listed in the header. No claims are made about runtime behavior
+without citation to the relevant design document.*


### PR DESCRIPTION
## Summary

Implements the Function Factory autonomous scheduler transition boundary so Factory can drive Codex as a worker runtime instead of relying on manual operator selection.

## Included

- ADR for the autonomous scheduler boundary and PR/branch-mode posture.
- Transition guide for moving from manual Codex operation to Function Factory scheduling.
- New @factory/autonomous-scheduler package.
- AgentRequest, AgentResult, QueueEvent, and evidence bundle contracts.
- Strategy.Recipes dogfood request/result fixtures.
- JSONL queue with claim leases, heartbeat, reclaim, events, and status.
- Codex runner planning and process execution seam.
- PR creation planning through gh pr create.
- Single-request scheduler path and bounded daemon loop.
- CLI for validate, enqueue, claim, heartbeat, status, plan, run-single, and daemon.

## Verification

- pnpm run autonomous-scheduler:test
- pnpm run autonomous-scheduler:typecheck
- CLI smoke: validate-request
- CLI smoke: enqueue + status
- CLI smoke: claim + heartbeat
- CLI smoke: daemon empty queue with --max-iterations 1

## Notes

Pre-existing local dirty files were left untouched:

- .agent/memory/episodic/AGENT_LEARNINGS.jsonl
- .agent/memory/working/WORKSPACE.md
- workers/ff-pipeline/src/index.ts