### PR TITLE
META: add Strategy.Recipes scheduler dogfood path

### DIFF
--- a/docs/AUTONOMOUS_FACTORY_TRANSITION.md
+++ b/docs/AUTONOMOUS_FACTORY_TRANSITION.md
@@ -66,6 +66,9 @@ The initial request fixture is:
 It asks a builder worker to implement the first Strategy.Recipes product view
 from `Strategy_Recipes_UX_Architecture_v1.1.md` in a separate repo and PR branch.
 
+Operational dry-run instructions live in
+[`STRATEGY_RECIPES_DOGFOOD.md`](STRATEGY_RECIPES_DOGFOOD.md).
+
 ## Production Alpha Exit Criteria
 
 Function Factory reaches production alpha autonomy when:

--- a/docs/STRATEGY_RECIPES_DOGFOOD.md
+++ b/docs/STRATEGY_RECIPES_DOGFOOD.md
@@ -1,0 +1,51 @@
+# Strategy.Recipes Dogfood
+
+Strategy.Recipes is an external product workload. Function Factory should build
+it through the autonomous scheduler boundary instead of relying on a human or
+Codex chat session to select each implementation step.
+
+## Dry Run
+
+Dry-run mode exercises the full scheduler path without invoking real `git`,
+`codex`, or `gh` commands:
+
+```bash
+pnpm run autonomous-scheduler:cli -- dogfood-strategy-recipes \
+  --repo-root /Users/wes/Developer/strategy-recipes
+```
+
+The command writes queue and evidence artifacts under:
+
+```text
+$HOME/.factory/dogfood/strategy-recipes/<run-id>/
+├── queue/
+└── bundle/
+```
+
+## Real Mode
+
+Real mode is intentionally explicit:
+
+```bash
+pnpm run autonomous-scheduler:cli -- dogfood-strategy-recipes \
+  --repo-root /Users/wes/Developer/strategy-recipes \
+  --real
+```
+
+Real mode runs the planned `git`, `codex`, and `gh pr create` commands against
+the Strategy.Recipes checkout. It still operates in PR/branch mode and does not
+merge, deploy, force-push, delete remote branches, or edit secrets.
+
+## Source Request
+
+The default request is:
+
+`packages/autonomous-scheduler/fixtures/strategy-recipes-agent-request.json`
+
+Override with:
+
+```bash
+pnpm run autonomous-scheduler:cli -- dogfood-strategy-recipes \
+  --request /path/to/request.json \
+  --repo-root /path/to/strategy-recipes
+```

--- a/packages/autonomous-scheduler/src/cli.ts
+++ b/packages/autonomous-scheduler/src/cli.ts
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
   JsonlAgentQueue,
+  createStrategyRecipesDogfoodRunPaths,
   createDryRunCommandExecutor,
   planCodexRunner,
   runQueueDaemon,
   runSingleAgentRequest,
+  runStrategyRecipesDogfood,
   validateAgentRequest,
 } from './index.js'
 
@@ -166,6 +170,43 @@ async function main(): Promise<void> {
       return
     }
 
+    if (command === 'dogfood-strategy-recipes') {
+      const requestPath = option(args, '--request') ?? fileURLToPath(
+        new URL('../fixtures/strategy-recipes-agent-request.json', import.meta.url),
+      )
+      const home = option(args, '--home') ?? join(process.env.HOME ?? process.cwd(), '.factory', 'dogfood')
+      const paths = createStrategyRecipesDogfoodRunPaths(join(home, 'strategy-recipes'))
+      const queueDir = option(args, '--queue-dir') ?? paths.queueDir
+      const bundleDir = option(args, '--bundle-dir') ?? paths.bundleDir
+      const repoRoot = option(args, '--repo-root') ?? process.env.STRATEGY_RECIPES_REPO ?? '/Users/wes/Developer/strategy-recipes'
+      const dogfoodOptions: Parameters<typeof runStrategyRecipesDogfood>[0] = {
+        request: await readJson(requestPath),
+        repoRoot,
+        queueDir,
+        bundleDir,
+        mode: hasFlag(args, '--real') ? 'real' : 'dry-run',
+      }
+      const changedFiles = csvOption(args, '--changed-files')
+      const mockPrUrl = option(args, '--mock-pr-url')
+      if (changedFiles) dogfoodOptions.changedFiles = changedFiles
+      if (mockPrUrl) dogfoodOptions.mockPrUrl = mockPrUrl
+
+      const dogfood = await runStrategyRecipesDogfood(dogfoodOptions)
+
+      printJson({
+        ok: true,
+        mode: dogfood.mode,
+        repoRoot: dogfood.repoRoot,
+        queueDir: dogfood.queueDir,
+        bundleDir: dogfood.bundleDir,
+        requestId: dogfood.outcome.request.id,
+        status: dogfood.outcome.result.status,
+        prUrl: dogfood.outcome.result.prUrl ?? null,
+        bundle: dogfood.outcome.bundle,
+      })
+      return
+    }
+
     throw new Error(`Unknown command: ${command}`)
   } catch (error) {
     process.exitCode = 1
@@ -189,8 +230,10 @@ function printHelp(): void {
     '  plan <request.json> --repo-root <path>',
     '  run-single <queue-dir> <request.json> --repo-root <path> --bundle-dir <path> [--changed-files a,b] [--diff-file path] [--dry-run]',
     '  daemon <queue-dir> --repo-root <path> --bundle-root <path> [--poll-ms n] [--max-iterations n] [--dry-run]',
+    '  dogfood-strategy-recipes [--repo-root path] [--home path] [--request path] [--real]',
     '',
     'run-single and daemon execute git, codex, and gh commands unless --dry-run is supplied.',
+    'dogfood-strategy-recipes defaults to dry-run mode.',
   ].join('\n'))
 }
 

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -330,6 +330,33 @@ export interface QueueDaemonOutcome {
   stopReason: 'max_iterations' | 'stop_requested'
 }
 
+export interface StrategyRecipesDogfoodRunPaths {
+  runId: string
+  runRoot: string
+  queueDir: string
+  bundleDir: string
+}
+
+export interface StrategyRecipesDogfoodOptions {
+  request: unknown
+  repoRoot: string
+  queueDir: string
+  bundleDir: string
+  mode?: 'dry-run' | 'real'
+  mockPrUrl?: string
+  changedFiles?: string[]
+  diff?: string
+  now?: () => Date
+}
+
+export interface StrategyRecipesDogfoodOutcome {
+  mode: 'dry-run' | 'real'
+  repoRoot: string
+  queueDir: string
+  bundleDir: string
+  outcome: SingleAgentRunOutcome
+}
+
 export class AutonomousSchedulerValidationError extends Error {
   public readonly issues: string[]
 
@@ -968,6 +995,57 @@ export async function runQueueDaemon(options: QueueDaemonOptions): Promise<Queue
   return { iterations, completedRuns, stopReason: 'max_iterations' }
 }
 
+export function createStrategyRecipesDogfoodRunPaths(
+  rootDir: string,
+  now: () => Date = () => new Date(),
+): StrategyRecipesDogfoodRunPaths {
+  const runId = `strategy-recipes-${now().toISOString().replace(/[^0-9TZ]/g, '')}`
+  const runRoot = join(rootDir, runId)
+
+  return {
+    runId,
+    runRoot,
+    queueDir: join(runRoot, 'queue'),
+    bundleDir: join(runRoot, 'bundle'),
+  }
+}
+
+export async function runStrategyRecipesDogfood(
+  options: StrategyRecipesDogfoodOptions,
+): Promise<StrategyRecipesDogfoodOutcome> {
+  const now = options.now ?? (() => new Date())
+  const request = validateAgentRequest(options.request)
+  const mode = options.mode ?? 'dry-run'
+  const completedAt = now().toISOString()
+  const stamp = completedAt.replace(/[^0-9TZ]/g, '')
+  const executor = mode === 'dry-run'
+    ? createDryRunCommandExecutor(buildDryRunOptions(options))
+    : undefined
+  const runOptions: SingleAgentRunOptions = {
+    queue: new JsonlAgentQueue({ queueDir: options.queueDir, actor: 'factory-dogfood', now }),
+    repoRoot: options.repoRoot,
+    bundleDir: options.bundleDir,
+    resultId: `ARES-${request.id.slice(3)}-${stamp}`,
+    agentRunId: `RUN-${request.id.slice(3)}-${stamp}`,
+    completedAt,
+    changedFiles: options.changedFiles ?? request.expectedArtifacts.map((artifact) => artifact.path),
+  }
+
+  if (options.diff !== undefined) runOptions.diff = options.diff
+  if (executor) {
+    runOptions.codexExecutor = executor
+    runOptions.pullRequestExecutor = executor
+  }
+
+  return {
+    mode,
+    repoRoot: options.repoRoot,
+    queueDir: options.queueDir,
+    bundleDir: options.bundleDir,
+    outcome: await runSingleAgentRequest(request, runOptions),
+  }
+}
+
 export class JsonlAgentQueue {
   private readonly queueDir: string
   private readonly actor: string
@@ -1569,6 +1647,13 @@ function buildPullRequestBody(request: AgentRequest, execution: CodexRunnerExecu
     'Required evidence:',
     ...request.evidenceRequired.map((kind) => `- ${kind}`),
   ].join('\n')
+}
+
+function buildDryRunOptions(options: StrategyRecipesDogfoodOptions): DryRunCommandExecutorOptions {
+  const dryRunOptions: DryRunCommandExecutorOptions = {}
+  if (options.now) dryRunOptions.now = options.now
+  if (options.mockPrUrl) dryRunOptions.prUrl = options.mockPrUrl
+  return dryRunOptions
 }
 
 async function spawnCommand(command: RunnerCommand): Promise<{ exitCode: number; stdout: string; stderr: string }> {

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -7,6 +7,7 @@ import {
   JsonlAgentQueue,
   buildAgentResultFromExecution,
   buildCodexWorkerPrompt,
+  createStrategyRecipesDogfoodRunPaths,
   createDryRunCommandExecutor,
   executeCodexRunnerPlan,
   executePullRequestPlan,
@@ -14,6 +15,7 @@ import {
   planPullRequest,
   runQueueDaemon,
   runSingleAgentRequest,
+  runStrategyRecipesDogfood,
   validateAgentRequest,
   validateAgentResult,
   validateQueueEvent,
@@ -635,6 +637,35 @@ describe('queue daemon', () => {
       completedRuns: 0,
       stopReason: 'stop_requested',
     })
+  })
+})
+
+describe('Strategy.Recipes dogfood', () => {
+  it('creates deterministic dogfood run paths', () => {
+    const paths = createStrategyRecipesDogfoodRunPaths('/tmp/factory-dogfood', fixedClock())
+
+    expect(paths.runId).toBe('strategy-recipes-20260430T143000000Z')
+    expect(paths.queueDir).toBe('/tmp/factory-dogfood/strategy-recipes-20260430T143000000Z/queue')
+    expect(paths.bundleDir).toBe('/tmp/factory-dogfood/strategy-recipes-20260430T143000000Z/bundle')
+  })
+
+  it('runs Strategy.Recipes dogfood in dry-run mode', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'factory-dogfood-'))
+    const paths = createStrategyRecipesDogfoodRunPaths(home, fixedClock())
+    const dogfood = await runStrategyRecipesDogfood({
+      request: requestFixture,
+      repoRoot: '/tmp/strategy-recipes',
+      queueDir: paths.queueDir,
+      bundleDir: paths.bundleDir,
+      mode: 'dry-run',
+      mockPrUrl: 'https://github.com/Wescome/strategy-recipes/pull/dogfood',
+      now: fixedClock(),
+    })
+
+    expect(dogfood.mode).toBe('dry-run')
+    expect(dogfood.outcome.result.status).toBe('completed')
+    expect(dogfood.outcome.result.prUrl).toBe('https://github.com/Wescome/strategy-recipes/pull/dogfood')
+    expect(readFileSync(dogfood.outcome.bundle.files.manifest, 'utf8')).toContain('factory.agent-result-bundle.v0')
   })
 })
 


### PR DESCRIPTION
## Summary

Adds a first-class Strategy.Recipes dogfood path for the autonomous scheduler. This lets Function Factory exercise the external product workload through queue, runner, PR, result, and bundle flow without manually selecting implementation steps.

## Included

- `dogfood-strategy-recipes` CLI command.
- Safe dry-run default; real execution requires `--real`.
- Run directories under `$HOME/.factory/dogfood/strategy-recipes/<run-id>/`.
- Strategy.Recipes dogfood helper functions and deterministic tests.
- Documentation for dry-run and real mode.

## Verification

- `pnpm run autonomous-scheduler:test`
- `pnpm run autonomous-scheduler:typecheck`
- `pnpm run autonomous-scheduler:cli -- dogfood-strategy-recipes --repo-root /Users/wes/Developer/strategy-recipes`

Dry-run output completed with status `completed`, mock PR URL `https://github.com/Wescome/strategy-recipes/pull/dry-run`, and bundle under `/Users/wes/.factory/dogfood/strategy-recipes/...`.

## Notes

Pre-existing local dirty files remain untouched:

- `.agent/memory/episodic/AGENT_LEARNINGS.jsonl`
- `.agent/memory/working/WORKSPACE.md`
- `workers/ff-pipeline/src/index.ts`
