### PR TITLE
META: make autonomous PR creation non-interactive

### DIFF
--- a/docs/STRATEGY_RECIPES_DOGFOOD.md
+++ b/docs/STRATEGY_RECIPES_DOGFOOD.md
@@ -36,6 +36,9 @@ Real mode runs the planned `git`, `codex`, and `gh pr create` commands against
 the Strategy.Recipes checkout. It still operates in PR/branch mode and does not
 merge, deploy, force-push, delete remote branches, or edit secrets.
 
+The scheduler pushes the worker branch before creating the pull request, so real
+mode is non-interactive at the GitHub PR boundary.
+
 ## Source Request
 
 The default request is:

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -281,6 +281,7 @@ export interface PullRequestPlan {
   branchName: string
   title: string
   body: string
+  pushCommand: RunnerCommand
   command: RunnerCommand
 }
 
@@ -288,6 +289,7 @@ export interface PullRequestExecution {
   requestId: string
   branchName: string
   prUrl: string
+  commands: CommandRunResult[]
   command: CommandRunResult
 }
 
@@ -850,6 +852,11 @@ export function planPullRequest(
     branchName: execution.branchName,
     title,
     body,
+    pushCommand: {
+      command: 'git',
+      args: ['push', '-u', 'origin', execution.branchName],
+      cwd: options.repoRoot,
+    },
     command: {
       command: 'gh',
       args: [
@@ -873,6 +880,12 @@ export async function executePullRequestPlan(
   plan: PullRequestPlan,
   executor: CommandExecutor = createProcessCommandExecutor(),
 ): Promise<PullRequestExecution> {
+  const pushCommand = await executor(plan.pushCommand)
+
+  if (pushCommand.exitCode !== 0) {
+    throw new Error(`Pull request branch push failed for ${plan.requestId}: ${pushCommand.stderr || pushCommand.stdout}`)
+  }
+
   const command = await executor(plan.command)
 
   if (command.exitCode !== 0) {
@@ -888,6 +901,7 @@ export async function executePullRequestPlan(
     requestId: plan.requestId,
     branchName: plan.branchName,
     prUrl,
+    commands: [pushCommand, command],
     command,
   }
 }

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -317,24 +317,66 @@ describe('Codex runner planning', () => {
     }))
 
     const prPlan = planPullRequest(requestFixture, execution, { repoRoot: '/tmp/strategy-recipes' })
+    expect(prPlan.pushCommand).toEqual({
+      command: 'git',
+      args: ['push', '-u', 'origin', 'factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view'],
+      cwd: '/tmp/strategy-recipes',
+    })
     expect(prPlan.command.command).toBe('gh')
     expect(prPlan.command.args.slice(0, 3)).toEqual(['pr', 'create', '--base'])
     expect(prPlan.command.args).toContain('main')
     expect(prPlan.command.args).toContain('factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view')
     expect(prPlan.body).toContain('Factory request: AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')
 
-    const pr = await executePullRequestPlan(prPlan, async (command) => ({
+    const executed: string[] = []
+    const pr = await executePullRequestPlan(prPlan, async (command) => {
+      executed.push(command.command)
+      return {
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: 0,
+        stdout: command.command === 'gh' ? 'https://github.com/Wescome/strategy-recipes/pull/4\n' : 'pushed\n',
+        stderr: '',
+        startedAt: '2026-04-30T14:36:00.000Z',
+        completedAt: '2026-04-30T14:36:01.000Z',
+      }
+    })
+
+    expect(executed).toEqual(['git', 'gh'])
+    expect(pr.commands).toHaveLength(2)
+    expect(pr.prUrl).toBe('https://github.com/Wescome/strategy-recipes/pull/4')
+  })
+
+  it('fails PR creation before gh when branch push fails', async () => {
+    const codexPlan = planCodexRunner(requestFixture, { repoRoot: '/tmp/strategy-recipes' })
+    const execution = await executeCodexRunnerPlan(codexPlan, async (command) => ({
       command: command.command,
       args: command.args,
       cwd: command.cwd,
       exitCode: 0,
-      stdout: 'https://github.com/Wescome/strategy-recipes/pull/4\n',
+      stdout: '',
       stderr: '',
-      startedAt: '2026-04-30T14:36:00.000Z',
-      completedAt: '2026-04-30T14:36:01.000Z',
+      startedAt: '2026-04-30T14:30:00.000Z',
+      completedAt: '2026-04-30T14:30:01.000Z',
     }))
+    const prPlan = planPullRequest(requestFixture, execution, { repoRoot: '/tmp/strategy-recipes' })
+    let calls = 0
 
-    expect(pr.prUrl).toBe('https://github.com/Wescome/strategy-recipes/pull/4')
+    await expect(executePullRequestPlan(prPlan, async (command) => {
+      calls += 1
+      return {
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: 1,
+        stdout: '',
+        stderr: 'push rejected',
+        startedAt: '2026-04-30T14:36:00.000Z',
+        completedAt: '2026-04-30T14:36:01.000Z',
+      }
+    })).rejects.toThrow('Pull request branch push failed for AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW: push rejected')
+    expect(calls).toBe(1)
   })
 
   it('does not plan PR creation for failed executions', async () => {


### PR DESCRIPTION
## Summary

Hardens real Strategy.Recipes dogfood execution by pushing the worker branch before invoking `gh pr create`. This removes the non-interactive GitHub boundary risk before the first real scheduler-driven external PR.

## Included

- `PullRequestPlan.pushCommand` with `git push -u origin <branch>`.
- `executePullRequestPlan` now runs branch push before PR creation and fails before `gh` if push fails.
- Tests for successful push + PR and push failure short-circuit.
- Dogfood docs note real mode is non-interactive at the PR boundary.

## Verification

- `pnpm run autonomous-scheduler:test`
- `pnpm run autonomous-scheduler:typecheck`
- `pnpm run autonomous-scheduler:cli -- dogfood-strategy-recipes --repo-root /Users/wes/Developer/strategy-recipes --home /tmp/factory-dogfood-pr-push`
