### PR TITLE
META: persist scheduler PR failure evidence

### DIFF
--- a/docs/STRATEGY_RECIPES_DOGFOOD.md
+++ b/docs/STRATEGY_RECIPES_DOGFOOD.md
@@ -39,6 +39,10 @@ merge, deploy, force-push, delete remote branches, or edit secrets.
 The scheduler pushes the worker branch before creating the pull request, so real
 mode is non-interactive at the GitHub PR boundary.
 
+Each dogfood run appends a run-specific branch suffix by default so retries do
+not collide with earlier scheduler-created branches. Use `--branch-suffix` to
+force a specific suffix.
+
 ## Source Request
 
 The default request is:

--- a/packages/autonomous-scheduler/src/cli.ts
+++ b/packages/autonomous-scheduler/src/cli.ts
@@ -188,8 +188,10 @@ async function main(): Promise<void> {
       }
       const changedFiles = csvOption(args, '--changed-files')
       const mockPrUrl = option(args, '--mock-pr-url')
+      const branchNameSuffix = option(args, '--branch-suffix')
       if (changedFiles) dogfoodOptions.changedFiles = changedFiles
       if (mockPrUrl) dogfoodOptions.mockPrUrl = mockPrUrl
+      if (branchNameSuffix) dogfoodOptions.branchNameSuffix = branchNameSuffix
 
       const dogfood = await runStrategyRecipesDogfood(dogfoodOptions)
 
@@ -230,7 +232,7 @@ function printHelp(): void {
     '  plan <request.json> --repo-root <path>',
     '  run-single <queue-dir> <request.json> --repo-root <path> --bundle-dir <path> [--changed-files a,b] [--diff-file path] [--dry-run]',
     '  daemon <queue-dir> --repo-root <path> --bundle-root <path> [--poll-ms n] [--max-iterations n] [--dry-run]',
-    '  dogfood-strategy-recipes [--repo-root path] [--home path] [--request path] [--real]',
+    '  dogfood-strategy-recipes [--repo-root path] [--home path] [--request path] [--branch-suffix text] [--real]',
     '',
     'run-single and daemon execute git, codex, and gh commands unless --dry-run is supplied.',
     'dogfood-strategy-recipes defaults to dry-run mode.',

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -198,6 +198,7 @@ export interface RunnerCommand {
 export interface CodexRunnerPlanOptions {
   repoRoot: string
   codexBinary?: string
+  branchNameSuffix?: string
 }
 
 export interface CodexRunnerPlan {
@@ -300,6 +301,7 @@ export interface SingleAgentRunOptions {
   resultId: string
   agentRunId: string
   completedAt: string
+  branchNameSuffix?: string
   changedFiles?: string[]
   diff?: string
   codexExecutor?: CommandExecutor
@@ -324,6 +326,7 @@ export interface QueueDaemonOptions {
   codexExecutor?: CommandExecutor
   pullRequestExecutor?: CommandExecutor
   now?: () => Date
+  branchNameSuffix?: string
 }
 
 export interface QueueDaemonOutcome {
@@ -346,6 +349,7 @@ export interface StrategyRecipesDogfoodOptions {
   bundleDir: string
   mode?: 'dry-run' | 'real'
   mockPrUrl?: string
+  branchNameSuffix?: string
   changedFiles?: string[]
   diff?: string
   now?: () => Date
@@ -366,6 +370,16 @@ export class AutonomousSchedulerValidationError extends Error {
     super(message)
     this.name = 'AutonomousSchedulerValidationError'
     this.issues = issues
+  }
+}
+
+export class PullRequestExecutionError extends Error {
+  public readonly commands: CommandRunResult[]
+
+  public constructor(message: string, commands: CommandRunResult[]) {
+    super(message)
+    this.name = 'PullRequestExecutionError'
+    this.commands = commands
   }
 }
 
@@ -522,7 +536,7 @@ export function planCodexRunner(input: unknown, options: CodexRunnerPlanOptions)
     throw new Error(`Codex runner cannot execute autonomyMode=${request.policy.autonomyMode}`)
   }
 
-  const branchName = buildBranchName(request)
+  const branchName = buildBranchName(request, options.branchNameSuffix)
   const codexBinary = options.codexBinary ?? 'codex'
   const prompt = buildCodexWorkerPrompt(request)
 
@@ -880,28 +894,40 @@ export async function executePullRequestPlan(
   plan: PullRequestPlan,
   executor: CommandExecutor = createProcessCommandExecutor(),
 ): Promise<PullRequestExecution> {
+  const commands: CommandRunResult[] = []
   const pushCommand = await executor(plan.pushCommand)
+  commands.push(pushCommand)
 
   if (pushCommand.exitCode !== 0) {
-    throw new Error(`Pull request branch push failed for ${plan.requestId}: ${pushCommand.stderr || pushCommand.stdout}`)
+    throw new PullRequestExecutionError(
+      `Pull request branch push failed for ${plan.requestId}: ${pushCommand.stderr || pushCommand.stdout}`,
+      commands,
+    )
   }
 
   const command = await executor(plan.command)
+  commands.push(command)
 
   if (command.exitCode !== 0) {
-    throw new Error(`Pull request creation failed for ${plan.requestId}: ${command.stderr || command.stdout}`)
+    throw new PullRequestExecutionError(
+      `Pull request creation failed for ${plan.requestId}: ${command.stderr || command.stdout}`,
+      commands,
+    )
   }
 
   const prUrl = command.stdout.trim().split('\n').find((line) => line.startsWith('https://'))
   if (!prUrl) {
-    throw new Error(`Pull request creation did not return a URL for ${plan.requestId}`)
+    throw new PullRequestExecutionError(
+      `Pull request creation did not return a URL for ${plan.requestId}`,
+      commands,
+    )
   }
 
   return {
     requestId: plan.requestId,
     branchName: plan.branchName,
     prUrl,
-    commands: [pushCommand, command],
+    commands,
     command,
   }
 }
@@ -927,13 +953,32 @@ export async function runClaimedAgentRequest(
   const claimed = validateAgentRequest(requestInput)
   await options.queue.heartbeat(claimed.id)
 
-  const codexPlan = planCodexRunner(claimed, { repoRoot: options.repoRoot })
+  const codexPlanOptions: CodexRunnerPlanOptions = {
+    repoRoot: options.repoRoot,
+  }
+  if (options.branchNameSuffix) codexPlanOptions.branchNameSuffix = options.branchNameSuffix
+
+  const codexPlan = planCodexRunner(claimed, codexPlanOptions)
   const execution = await executeCodexRunnerPlan(codexPlan, options.codexExecutor)
+  let resultExecution = execution
   let pullRequest: PullRequestExecution | undefined
 
   if (execution.status === 'completed') {
     const prPlan = planPullRequest(claimed, execution, { repoRoot: options.repoRoot })
-    pullRequest = await executePullRequestPlan(prPlan, options.pullRequestExecutor)
+    try {
+      pullRequest = await executePullRequestPlan(prPlan, options.pullRequestExecutor)
+    } catch (error) {
+      if (!(error instanceof PullRequestExecutionError)) {
+        throw error
+      }
+      resultExecution = {
+        requestId: execution.requestId,
+        branchName: execution.branchName,
+        status: 'failed',
+        commands: [...execution.commands, ...error.commands],
+        failedCommand: 'pull request creation',
+      }
+    }
   }
 
   const resultOptions: AgentResultFromExecutionOptions = {
@@ -945,20 +990,20 @@ export async function runClaimedAgentRequest(
   if (pullRequest) resultOptions.prUrl = pullRequest.prUrl
   if (options.changedFiles) resultOptions.changedFiles = options.changedFiles
 
-  const result = buildAgentResultFromExecution(claimed, execution, resultOptions)
+  const result = buildAgentResultFromExecution(claimed, resultExecution, resultOptions)
 
   const bundleOptions: AgentResultBundleOptions = {
     bundleDir: options.bundleDir,
   }
   if (options.diff !== undefined) bundleOptions.diff = options.diff
 
-  const bundle = await writeAgentResultBundle(claimed, execution, result, bundleOptions)
+  const bundle = await writeAgentResultBundle(claimed, resultExecution, result, bundleOptions)
 
   await options.queue.complete(result)
 
   const outcome: SingleAgentRunOutcome = {
     request: claimed,
-    execution,
+    execution: resultExecution,
     result,
     bundle,
   }
@@ -997,6 +1042,7 @@ export async function runQueueDaemon(options: QueueDaemonOptions): Promise<Queue
       resultId: `ARES-${request.id.slice(3)}-${stamp}`,
       agentRunId: `RUN-${request.id.slice(3)}-${stamp}`,
       completedAt: now().toISOString(),
+      branchNameSuffix: options.branchNameSuffix ?? stamp,
       changedFiles: request.expectedArtifacts.map((artifact) => artifact.path),
     }
     if (options.codexExecutor) runOptions.codexExecutor = options.codexExecutor
@@ -1042,6 +1088,7 @@ export async function runStrategyRecipesDogfood(
     resultId: `ARES-${request.id.slice(3)}-${stamp}`,
     agentRunId: `RUN-${request.id.slice(3)}-${stamp}`,
     completedAt,
+    branchNameSuffix: options.branchNameSuffix ?? stamp,
     changedFiles: options.changedFiles ?? request.expectedArtifacts.map((artifact) => artifact.path),
   }
 
@@ -1632,8 +1679,10 @@ function sanitizeId(id: string): string {
   return id.replace(/[^A-Za-z0-9_-]/g, '-')
 }
 
-function buildBranchName(request: AgentRequest): string {
-  return `${request.branch.prefix}/${sanitizeId(request.id).toLowerCase()}`
+function buildBranchName(request: AgentRequest, suffix?: string): string {
+  const baseName = `${request.branch.prefix}/${sanitizeId(request.id).toLowerCase()}`
+  if (!suffix) return baseName
+  return `${baseName}-${sanitizeId(suffix).toLowerCase()}`
 }
 
 function stringifyCommand(command: RunnerCommand): string {

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 import {
   AutonomousSchedulerValidationError,
   JsonlAgentQueue,
+  PullRequestExecutionError,
   buildAgentResultFromExecution,
   buildCodexWorkerPrompt,
   createStrategyRecipesDogfoodRunPaths,
@@ -129,6 +130,17 @@ describe('Codex runner planning', () => {
     expect(plan.codexCommand.args[0]).toBe('exec')
     expect(plan.prompt).toContain('Allowed paths: README.md, docs/**, packages/**, apps/**, examples/**, tests/**')
     expect(plan.prompt).toContain('Do not merge, deploy, force-push, delete remote branches, edit secrets')
+  })
+
+  it('adds an optional branch suffix for retryable dogfood runs', () => {
+    const plan = planCodexRunner(requestFixture, {
+      repoRoot: '/tmp/strategy-recipes',
+      branchNameSuffix: '20260430T202400735Z',
+    })
+
+    expect(plan.branchName).toBe(
+      'factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view-20260430t202400735z',
+    )
   })
 
   it('builds a worker prompt with required commands and evidence', () => {
@@ -375,7 +387,7 @@ describe('Codex runner planning', () => {
         startedAt: '2026-04-30T14:36:00.000Z',
         completedAt: '2026-04-30T14:36:01.000Z',
       }
-    })).rejects.toThrow('Pull request branch push failed for AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW: push rejected')
+    })).rejects.toThrow(PullRequestExecutionError)
     expect(calls).toBe(1)
   })
 
@@ -608,6 +620,51 @@ describe('single-request scheduler run', () => {
       total: 1,
       failed: 1,
     })
+  })
+
+  it('completes the queue with failed evidence when PR creation fails', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'factory-autonomous-'))
+    const queue = new JsonlAgentQueue({
+      queueDir: join(home, 'queue'),
+      actor: 'factory-governor',
+      now: fixedClock(),
+    })
+
+    const outcome = await runSingleAgentRequest(requestFixture, {
+      queue,
+      repoRoot: '/tmp/strategy-recipes',
+      bundleDir: join(home, 'bundle'),
+      resultId: 'ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-PR-FAILED',
+      agentRunId: 'RUN-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-007',
+      completedAt: '2026-04-30T14:40:00.000Z',
+      changedFiles: ['docs/product/first-product-view.md'],
+      codexExecutor: async (command) => ({
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        startedAt: '2026-04-30T14:30:00.000Z',
+        completedAt: '2026-04-30T14:30:01.000Z',
+      }),
+      pullRequestExecutor: async (command) => ({
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: command.command === 'gh' ? 1 : 0,
+        stdout: command.command === 'gh' ? '' : 'pushed',
+        stderr: command.command === 'gh' ? 'no commits' : '',
+        startedAt: '2026-04-30T14:36:00.000Z',
+        completedAt: '2026-04-30T14:36:01.000Z',
+      }),
+    })
+
+    expect(outcome.result.status).toBe('failed')
+    expect(outcome.execution.failedCommand).toBe('pull request creation')
+    expect(outcome.execution.commands.map((command) => command.command)).toEqual(['git', 'git', 'git', 'codex', 'git', 'gh'])
+    expect(readFileSync(outcome.bundle.files.result, 'utf8')).toContain('ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-PR-FAILED')
+    expect(await queue.status()).toMatchObject({ total: 1, failed: 1 })
   })
 })
 


### PR DESCRIPTION
## Summary

Hardens the real dogfood path after the first live run exposed two gaps: PR-boundary exceptions were not converted into scheduler evidence, and deterministic branch names collided on retries.

## Included

- `PullRequestExecutionError` carries push/create command evidence.
- `runClaimedAgentRequest` converts PR creation failures into failed `AgentResult` bundles and completes the queue item.
- Optional `branchNameSuffix` for retryable runs.
- Strategy.Recipes dogfood defaults to run-specific branch suffixes.
- Tests for retry branch naming and PR failure evidence persistence.

## Verification

- `pnpm run autonomous-scheduler:test`
- `pnpm run autonomous-scheduler:typecheck`
- `pnpm run autonomous-scheduler:cli -- dogfood-strategy-recipes --repo-root /Users/wes/Developer/strategy-recipes --home /tmp/factory-dogfood-failure-evidence`

## Live-run finding addressed

The first real dogfood attempt reached `gh pr create` and failed because there were no commits between `main` and the scheduler branch. This PR makes that kind of failure observable as a failed scheduler result instead of an unhandled process failure.
