### PR TITLE
Bound autonomous Codex worker execution

### DIFF
--- a/packages/autonomous-scheduler/src/cli.ts
+++ b/packages/autonomous-scheduler/src/cli.ts
@@ -84,7 +84,10 @@ async function main(): Promise<void> {
     if (command === 'plan') {
       const request = await readJson(requiredArg(args, 0, 'request file'))
       const repoRoot = requiredOption(args, '--repo-root')
-      const plan = planCodexRunner(request, { repoRoot })
+      const codexTimeoutMs = numberOption(args, '--codex-timeout-ms')
+      const planOptions: Parameters<typeof planCodexRunner>[1] = { repoRoot }
+      if (codexTimeoutMs !== undefined) planOptions.codexTimeoutMs = codexTimeoutMs
+      const plan = planCodexRunner(request, planOptions)
       printJson({
         ok: true,
         requestId: plan.requestId,
@@ -92,8 +95,13 @@ async function main(): Promise<void> {
         preflightCommands: plan.preflightCommands,
         codexCommand: {
           command: plan.codexCommand.command,
-          args: [plan.codexCommand.args[0], '<prompt omitted>'],
+          args: [
+            plan.codexCommand.args[0],
+            ...plan.codexCommand.args.slice(1, -1),
+            '<prompt omitted>',
+          ],
           cwd: plan.codexCommand.cwd,
+          timeoutMs: plan.codexCommand.timeoutMs,
         },
         prompt: plan.prompt,
       })
@@ -127,6 +135,8 @@ async function main(): Promise<void> {
       }
       if (changedFiles) runOptions.changedFiles = changedFiles
       if (diff !== undefined) runOptions.diff = diff
+      const codexTimeoutMs = numberOption(args, '--codex-timeout-ms')
+      if (codexTimeoutMs !== undefined) runOptions.codexTimeoutMs = codexTimeoutMs
       if (dryRunExecutor) {
         runOptions.codexExecutor = dryRunExecutor
         runOptions.pullRequestExecutor = dryRunExecutor
@@ -156,6 +166,8 @@ async function main(): Promise<void> {
       }
       const maxIterations = numberOption(args, '--max-iterations')
       if (maxIterations !== undefined) daemonOptions.maxIterations = maxIterations
+      const codexTimeoutMs = numberOption(args, '--codex-timeout-ms')
+      if (codexTimeoutMs !== undefined) daemonOptions.codexTimeoutMs = codexTimeoutMs
       const dryRunExecutor = hasFlag(args, '--dry-run')
         ? createDryRunExecutorFromArgs(args)
         : undefined
@@ -192,6 +204,8 @@ async function main(): Promise<void> {
       if (changedFiles) dogfoodOptions.changedFiles = changedFiles
       if (mockPrUrl) dogfoodOptions.mockPrUrl = mockPrUrl
       if (branchNameSuffix) dogfoodOptions.branchNameSuffix = branchNameSuffix
+      const codexTimeoutMs = numberOption(args, '--codex-timeout-ms')
+      if (codexTimeoutMs !== undefined) dogfoodOptions.codexTimeoutMs = codexTimeoutMs
 
       const dogfood = await runStrategyRecipesDogfood(dogfoodOptions)
 
@@ -229,10 +243,10 @@ function printHelp(): void {
     '  claim <queue-dir> [--actor name] [--lease-ms n]',
     '  heartbeat <queue-dir> <request-id> [--actor name] [--lease-ms n]',
     '  status <queue-dir> [--actor name]',
-    '  plan <request.json> --repo-root <path>',
-    '  run-single <queue-dir> <request.json> --repo-root <path> --bundle-dir <path> [--changed-files a,b] [--diff-file path] [--dry-run]',
-    '  daemon <queue-dir> --repo-root <path> --bundle-root <path> [--poll-ms n] [--max-iterations n] [--dry-run]',
-    '  dogfood-strategy-recipes [--repo-root path] [--home path] [--request path] [--branch-suffix text] [--real]',
+    '  plan <request.json> --repo-root <path> [--codex-timeout-ms n]',
+    '  run-single <queue-dir> <request.json> --repo-root <path> --bundle-dir <path> [--changed-files a,b] [--diff-file path] [--codex-timeout-ms n] [--dry-run]',
+    '  daemon <queue-dir> --repo-root <path> --bundle-root <path> [--poll-ms n] [--max-iterations n] [--codex-timeout-ms n] [--dry-run]',
+    '  dogfood-strategy-recipes [--repo-root path] [--home path] [--request path] [--branch-suffix text] [--codex-timeout-ms n] [--real]',
     '',
     'run-single and daemon execute git, codex, and gh commands unless --dry-run is supplied.',
     'dogfood-strategy-recipes defaults to dry-run mode.',

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 export const AGENT_REQUEST_SCHEMA_VERSION = 'factory.agent-request.v0' as const
 export const AGENT_RESULT_SCHEMA_VERSION = 'factory.agent-result.v0' as const
 export const QUEUE_EVENT_SCHEMA_VERSION = 'factory.queue-event.v0' as const
+export const DEFAULT_CODEX_TIMEOUT_MS = 30 * 60 * 1000
 
 export const AGENT_ROLES = [
   'architect',
@@ -193,12 +194,14 @@ export interface RunnerCommand {
   command: string
   args: string[]
   cwd: string
+  timeoutMs?: number
 }
 
 export interface CodexRunnerPlanOptions {
   repoRoot: string
   codexBinary?: string
   branchNameSuffix?: string
+  codexTimeoutMs?: number
 }
 
 export interface CodexRunnerPlan {
@@ -219,6 +222,8 @@ export interface CommandRunResult {
   stderr: string
   startedAt: string
   completedAt: string
+  timedOut?: boolean
+  signal?: string
 }
 
 export interface CodexRunnerExecution {
@@ -234,6 +239,7 @@ export type CommandExecutor = (command: RunnerCommand) => Promise<CommandRunResu
 
 export interface ProcessCommandExecutorOptions {
   now?: () => Date
+  timeoutMs?: number
 }
 
 export interface DryRunCommandExecutorOptions {
@@ -307,6 +313,7 @@ export interface SingleAgentRunOptions {
   diff?: string
   codexExecutor?: CommandExecutor
   pullRequestExecutor?: CommandExecutor
+  codexTimeoutMs?: number
 }
 
 export interface SingleAgentRunOutcome {
@@ -328,6 +335,7 @@ export interface QueueDaemonOptions {
   pullRequestExecutor?: CommandExecutor
   now?: () => Date
   branchNameSuffix?: string
+  codexTimeoutMs?: number
 }
 
 export interface QueueDaemonOutcome {
@@ -354,6 +362,7 @@ export interface StrategyRecipesDogfoodOptions {
   changedFiles?: string[]
   diff?: string
   now?: () => Date
+  codexTimeoutMs?: number
 }
 
 export interface StrategyRecipesDogfoodOutcome {
@@ -566,6 +575,7 @@ export function planCodexRunner(input: unknown, options: CodexRunnerPlanOptions)
       command: codexBinary,
       args: ['exec', '--sandbox', 'workspace-write', '--cd', options.repoRoot, prompt],
       cwd: options.repoRoot,
+      timeoutMs: options.codexTimeoutMs ?? DEFAULT_CODEX_TIMEOUT_MS,
     },
     prompt,
   }
@@ -630,7 +640,9 @@ export async function executeCodexRunnerPlan(
         branchName: plan.branchName,
         status: 'failed',
         commands,
-        failedCommand: stringifyCommand(command),
+        failedCommand: result.timedOut
+          ? `${stringifyCommand(command)} timed out`
+          : stringifyCommand(command),
       }
     }
 
@@ -662,10 +674,13 @@ export function createProcessCommandExecutor(options?: ProcessCommandExecutorOpt
 
   return async (command: RunnerCommand): Promise<CommandRunResult> => {
     const startedAt = now().toISOString()
-    const { exitCode, stdout, stderr } = await spawnCommand(command)
+    const timeoutMs = command.timeoutMs ?? options?.timeoutMs
+    const spawnOptions: SpawnCommandOptions = {}
+    if (timeoutMs !== undefined) spawnOptions.timeoutMs = timeoutMs
+    const { exitCode, stdout, stderr, timedOut, signal } = await spawnCommand(command, spawnOptions)
     const completedAt = now().toISOString()
 
-    return {
+    const result: CommandRunResult = {
       command: command.command,
       args: command.args,
       cwd: command.cwd,
@@ -675,6 +690,11 @@ export function createProcessCommandExecutor(options?: ProcessCommandExecutorOpt
       startedAt,
       completedAt,
     }
+
+    if (timedOut) result.timedOut = true
+    if (signal) result.signal = signal
+
+    return result
   }
 }
 
@@ -976,6 +996,7 @@ export async function runClaimedAgentRequest(
     repoRoot: options.repoRoot,
   }
   if (options.branchNameSuffix) codexPlanOptions.branchNameSuffix = options.branchNameSuffix
+  if (options.codexTimeoutMs !== undefined) codexPlanOptions.codexTimeoutMs = options.codexTimeoutMs
 
   const codexPlan = planCodexRunner(claimed, codexPlanOptions)
   const execution = await executeCodexRunnerPlan(codexPlan, options.codexExecutor)
@@ -1066,6 +1087,7 @@ export async function runQueueDaemon(options: QueueDaemonOptions): Promise<Queue
     }
     if (options.codexExecutor) runOptions.codexExecutor = options.codexExecutor
     if (options.pullRequestExecutor) runOptions.pullRequestExecutor = options.pullRequestExecutor
+    if (options.codexTimeoutMs !== undefined) runOptions.codexTimeoutMs = options.codexTimeoutMs
 
     await runClaimedAgentRequest(request, runOptions)
     completedRuns += 1
@@ -1112,6 +1134,7 @@ export async function runStrategyRecipesDogfood(
   }
 
   if (options.diff !== undefined) runOptions.diff = options.diff
+  if (options.codexTimeoutMs !== undefined) runOptions.codexTimeoutMs = options.codexTimeoutMs
   if (executor) {
     runOptions.codexExecutor = executor
     runOptions.pullRequestExecutor = executor
@@ -1705,7 +1728,16 @@ function buildBranchName(request: AgentRequest, suffix?: string): string {
 }
 
 function stringifyCommand(command: RunnerCommand): string {
-  return [command.command, ...command.args].join(' ')
+  return [command.command, ...redactCommandArgs(command)].join(' ')
+}
+
+function redactCommandArgs(command: RunnerCommand): string[] {
+  if (command.command !== 'codex') return command.args
+  const args = [...command.args]
+  if (args[0] === 'exec' && args.length > 1) {
+    args[args.length - 1] = '<prompt omitted>'
+  }
+  return args
 }
 
 function defaultExecutionSummary(request: AgentRequest, execution: CodexRunnerExecution): string {
@@ -1770,14 +1802,40 @@ function buildDryRunOptions(options: StrategyRecipesDogfoodOptions): DryRunComma
   return dryRunOptions
 }
 
-async function spawnCommand(command: RunnerCommand): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+interface SpawnCommandOptions {
+  timeoutMs?: number
+}
+
+interface SpawnCommandResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+  timedOut?: boolean
+  signal?: string
+}
+
+async function spawnCommand(command: RunnerCommand, options?: SpawnCommandOptions): Promise<SpawnCommandResult> {
   return await new Promise((resolve, reject) => {
     const child = spawn(command.command, command.args, {
       cwd: command.cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
     })
     const stdout: Buffer[] = []
     const stderr: Buffer[] = []
+    let timedOut = false
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    let killTimeout: ReturnType<typeof setTimeout> | undefined
+
+    if (options?.timeoutMs !== undefined) {
+      timeout = setTimeout(() => {
+        timedOut = true
+        killChildProcess(child.pid, 'SIGTERM')
+        killTimeout = setTimeout(() => {
+          killChildProcess(child.pid, 'SIGKILL')
+        }, 2_000)
+      }, options.timeoutMs)
+    }
 
     child.stdout.on('data', (chunk: Buffer) => {
       stdout.push(chunk)
@@ -1786,14 +1844,40 @@ async function spawnCommand(command: RunnerCommand): Promise<{ exitCode: number;
       stderr.push(chunk)
     })
     child.on('error', reject)
-    child.on('close', (code) => {
+    child.on('close', (code, signal) => {
+      if (timeout) clearTimeout(timeout)
+      if (killTimeout) clearTimeout(killTimeout)
+      const stderrText = Buffer.concat(stderr).toString('utf8')
       resolve({
-        exitCode: code ?? 1,
+        exitCode: timedOut ? 124 : code ?? 1,
         stdout: Buffer.concat(stdout).toString('utf8'),
-        stderr: Buffer.concat(stderr).toString('utf8'),
+        stderr: timedOut
+          ? `${stderrText}${stderrText.endsWith('\n') || stderrText.length === 0 ? '' : '\n'}Command timed out after ${options?.timeoutMs}ms.`
+          : stderrText,
+        ...(timedOut ? { timedOut: true } : {}),
+        ...(signal ? { signal } : {}),
       })
     })
   })
+}
+
+function killChildProcess(pid: number | undefined, signal: NodeJS.Signals): void {
+  if (!pid) return
+
+  try {
+    if (process.platform === 'win32') {
+      process.kill(pid, signal)
+      return
+    }
+
+    process.kill(-pid, signal)
+  } catch (error) {
+    if (!isNoSuchProcess(error)) throw error
+  }
+}
+
+function isNoSuchProcess(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ESRCH'
 }
 
 function isNotFound(error: unknown): boolean {

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -8,6 +8,7 @@ import {
   PullRequestExecutionError,
   buildAgentResultFromExecution,
   buildCodexWorkerPrompt,
+  createProcessCommandExecutor,
   createStrategyRecipesDogfoodRunPaths,
   createDryRunCommandExecutor,
   executeCodexRunnerPlan,
@@ -135,8 +136,18 @@ describe('Codex runner planning', () => {
       '/tmp/strategy-recipes',
       plan.prompt,
     ])
+    expect(plan.codexCommand.timeoutMs).toBe(30 * 60 * 1000)
     expect(plan.prompt).toContain('Allowed paths: README.md, docs/**, packages/**, apps/**, examples/**, tests/**')
     expect(plan.prompt).toContain('Do not merge, deploy, force-push, delete remote branches, edit secrets')
+  })
+
+  it('allows runner plans to bound child Codex execution time', () => {
+    const plan = planCodexRunner(requestFixture, {
+      repoRoot: '/tmp/strategy-recipes',
+      codexTimeoutMs: 1_000,
+    })
+
+    expect(plan.codexCommand.timeoutMs).toBe(1_000)
   })
 
   it('adds an optional branch suffix for retryable dogfood runs', () => {
@@ -215,6 +226,38 @@ describe('Codex runner planning', () => {
     expect(execution.failedCommand).toBe(
       'git switch -c factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view origin/main',
     )
+  })
+
+  it('marks timed-out process commands as failed command evidence', async () => {
+    const executor = createProcessCommandExecutor()
+    const result = await executor({
+      command: process.execPath,
+      args: ['-e', 'setTimeout(() => {}, 5000)'],
+      cwd: tmpdir(),
+      timeoutMs: 10,
+    })
+
+    expect(result.exitCode).toBe(124)
+    expect(result.timedOut).toBe(true)
+    expect(result.stderr).toContain('Command timed out after 10ms.')
+  })
+
+  it('redacts long Codex prompts from failed command summaries', async () => {
+    const plan = planCodexRunner(requestFixture, { repoRoot: '/tmp/strategy-recipes' })
+    const execution = await executeCodexRunnerPlan(plan, async (command) => ({
+      command: command.command,
+      args: command.args,
+      cwd: command.cwd,
+      exitCode: command.command === 'codex' ? 1 : 0,
+      stdout: '',
+      stderr: command.command === 'codex' ? 'worker failed' : '',
+      startedAt: '2026-04-30T14:30:00.000Z',
+      completedAt: '2026-04-30T14:30:01.000Z',
+    }))
+
+    expect(execution.status).toBe('failed')
+    expect(execution.failedCommand).toContain('<prompt omitted>')
+    expect(execution.failedCommand).not.toContain('You are a Function Factory Codex worker.')
   })
 
   it('classifies model-level Codex refusals as refused executions', async () => {


### PR DESCRIPTION
## Summary
- add command-level `timeoutMs` and a default 30-minute child Codex timeout
- expose `--codex-timeout-ms` on scheduler CLI plan, run-single, daemon, and Strategy.Recipes dogfood paths
- mark timed-out child commands as failed evidence with exit code 124
- redact long Codex prompts from failed command summaries and command bundle headers

## Dogfood Evidence
- Strategy.Recipes PR #68 landed from the previous Function Factory dogfood run
- The run showed the child worker can produce a real branch, but unbounded child execution is unsafe for production autonomy

## Validation
- `pnpm run autonomous-scheduler:test`
- `pnpm run autonomous-scheduler:typecheck`
- `pnpm run autonomous-scheduler:cli -- plan packages/autonomous-scheduler/fixtures/strategy-recipes-agent-request.json --repo-root /Users/wes/Developer/strategy-recipes --codex-timeout-ms 1000`
- `pnpm run autonomous-scheduler:cli -- dogfood-strategy-recipes --repo-root /Users/wes/Developer/strategy-recipes --home /tmp/factory-dogfood-timeout-XXXXXX --codex-timeout-ms 1000`
