### PR TITLE
Refresh Strategy.Recipes dogfood request

### DIFF
--- a/docs/STRATEGY_RECIPES_DOGFOOD.md
+++ b/docs/STRATEGY_RECIPES_DOGFOOD.md
@@ -47,6 +47,11 @@ force a specific suffix.
 
 The default request is:
 
+`packages/autonomous-scheduler/fixtures/strategy-recipes-package-readme-agent-request.json`
+
+The original first-product-view request remains available as a historical
+fixture:
+
 `packages/autonomous-scheduler/fixtures/strategy-recipes-agent-request.json`
 
 Override with:

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -68,3 +68,12 @@ pnpm run autonomous-scheduler:cli -- run-single /tmp/factory-queue \
 
 Queue claims include leases and heartbeats. Expired claims can be reclaimed by a
 later runner; active claims are excluded from pending queue counts.
+
+The `dogfood-strategy-recipes` command defaults to the current next-slice
+request:
+
+```text
+packages/autonomous-scheduler/fixtures/strategy-recipes-package-readme-agent-request.json
+```
+
+Use `--request` to replay older fixtures or run a freshly generated request.

--- a/packages/autonomous-scheduler/fixtures/strategy-recipes-package-readme-agent-request.json
+++ b/packages/autonomous-scheduler/fixtures/strategy-recipes-package-readme-agent-request.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": "factory.agent-request.v0",
+  "id": "AR-STRATEGY-RECIPES-PACKAGE-README",
+  "createdAt": "2026-04-30T20:55:00.000Z",
+  "workgraph": {
+    "id": "WG-STRATEGY-RECIPES-PACKAGE-README",
+    "nodeId": "package-readme",
+    "sourcePrdId": "PRD-STRATEGY-RECIPES-UX-V1-1",
+    "sourceRefs": [
+      "Strategy_Recipes_UX_Architecture_v1.1.md",
+      "PR-68-strategy-recipes-first-product-view",
+      "ADR-0001-autonomous-scheduler-boundary.md"
+    ]
+  },
+  "role": "builder",
+  "objective": "Add package-level documentation for the Strategy.Recipes first product view workload.",
+  "prompt": "Add a concise package README for the merged Strategy.Recipes object workload. Keep the package isolated from the live browser runtime. Document purpose, exported concepts, verification commands, and how it relates to the first product view. Link it from the existing product doc.",
+  "repo": {
+    "provider": "github",
+    "owner": "Wescome",
+    "name": "strategy-recipes",
+    "defaultBranch": "main",
+    "remoteUrl": "https://github.com/Wescome/strategy-recipes.git"
+  },
+  "branch": {
+    "mode": "new_pr_branch",
+    "base": "main",
+    "prefix": "factory/strategy-recipes-package-readme"
+  },
+  "policy": {
+    "autonomyMode": "branch_pr",
+    "allowedPaths": [
+      "docs/product/**",
+      "packages/strategy-objects/**",
+      "tests/first-product-view.test.ts",
+      "README.md"
+    ],
+    "forbiddenActions": [
+      "merge_default_branch",
+      "deploy_production",
+      "force_push",
+      "delete_remote_branch",
+      "edit_secrets"
+    ],
+    "requiresHumanApprovalFor": [
+      "merge_default_branch",
+      "deploy_production",
+      "edit_secrets"
+    ],
+    "maxRuntimeMinutes": 45
+  },
+  "context": {
+    "summary": "Strategy.Recipes PR #68 added the first external Function Factory workload. The next safe autonomous slice is package-level documentation and verification clarity.",
+    "artifacts": [
+      {
+        "id": "STRATEGY-RECIPES-UX-V1-1",
+        "kind": "external-design",
+        "path": "/Users/wes/Downloads/Strategy_Recipes_UX_Architecture_v1.1.md"
+      },
+      {
+        "id": "PR-68-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW",
+        "kind": "github-pr",
+        "path": "https://github.com/Wescome/strategy-recipes/pull/68"
+      }
+    ]
+  },
+  "acceptanceCriteria": [
+    "packages/strategy-objects/README.md explains the package purpose, exported concepts, verification commands, and isolation boundary.",
+    "docs/product/first-product-view.md links or references the package README.",
+    "The change does not alter app/, server/, packaging/, or live Strategy.Recipes runtime behavior.",
+    "The PR includes package test and type-load check evidence."
+  ],
+  "requiredCommands": [
+    "pnpm --dir packages/strategy-objects test",
+    "pnpm --dir packages/strategy-objects typecheck",
+    "npm run test:strategy-recipes"
+  ],
+  "expectedArtifacts": [
+    {
+      "path": "packages/strategy-objects/README.md",
+      "kind": "product-doc"
+    },
+    {
+      "path": "docs/product/first-product-view.md",
+      "kind": "product-doc"
+    }
+  ],
+  "evidenceRequired": [
+    "git_diff",
+    "test_output",
+    "typecheck_output",
+    "artifact_paths",
+    "pr_url"
+  ]
+}

--- a/packages/autonomous-scheduler/src/cli.ts
+++ b/packages/autonomous-scheduler/src/cli.ts
@@ -184,7 +184,7 @@ async function main(): Promise<void> {
 
     if (command === 'dogfood-strategy-recipes') {
       const requestPath = option(args, '--request') ?? fileURLToPath(
-        new URL('../fixtures/strategy-recipes-agent-request.json', import.meta.url),
+        new URL('../fixtures/strategy-recipes-package-readme-agent-request.json', import.meta.url),
       )
       const home = option(args, '--home') ?? join(process.env.HOME ?? process.cwd(), '.factory', 'dogfood')
       const paths = createStrategyRecipesDogfoodRunPaths(join(home, 'strategy-recipes'))

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -28,6 +28,10 @@ const requestFixture = JSON.parse(
   readFileSync(new URL('../fixtures/strategy-recipes-agent-request.json', import.meta.url), 'utf8'),
 ) as unknown
 
+const packageReadmeRequestFixture = JSON.parse(
+  readFileSync(new URL('../fixtures/strategy-recipes-package-readme-agent-request.json', import.meta.url), 'utf8'),
+) as unknown
+
 const resultFixture = JSON.parse(
   readFileSync(new URL('../fixtures/strategy-recipes-agent-result.json', import.meta.url), 'utf8'),
 ) as unknown
@@ -42,6 +46,15 @@ describe('autonomous scheduler contracts', () => {
     expect(request.branch.mode).toBe('new_pr_branch')
     expect(request.policy.autonomyMode).toBe('branch_pr')
     expect(request.workgraph.sourceRefs).toContain('Strategy_Recipes_UX_Architecture_v1.1.md')
+  })
+
+  it('validates the current Strategy.Recipes dogfood next-slice request fixture', () => {
+    const request = validateAgentRequest(packageReadmeRequestFixture)
+
+    expect(request.id).toBe('AR-STRATEGY-RECIPES-PACKAGE-README')
+    expect(request.branch.prefix).toBe('factory/strategy-recipes-package-readme')
+    expect(request.requiredCommands).toContain('pnpm --dir packages/strategy-objects test')
+    expect(request.expectedArtifacts.map((artifact) => artifact.path)).toContain('packages/strategy-objects/README.md')
   })
 
   it('validates a completed AgentResult with PR evidence', () => {


### PR DESCRIPTION
## Summary
- add a current next-slice Strategy.Recipes AgentRequest fixture for package README work
- point `dogfood-strategy-recipes` default at the new fixture
- document that the original first-product-view fixture is now historical
- test validation for the new request fixture

## Validation
- `pnpm run autonomous-scheduler:test`
- `pnpm run autonomous-scheduler:typecheck`
- `pnpm run autonomous-scheduler:cli -- dogfood-strategy-recipes --repo-root /Users/wes/Developer/strategy-recipes --home /tmp/factory-dogfood-next-XXXXXX`
