### PR TITLE
Commit worker changes from scheduler parent

### DIFF
--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -37,9 +37,15 @@ also planned and executed through the same command seam using `gh pr create`.
 1. Enqueue an `AgentRequest`.
 2. Claim it from the JSONL queue.
 3. Execute the Codex runner plan.
-4. Create a PR if the runner succeeds.
-5. Build and persist a validated `AgentResult` bundle.
-6. Complete the queue item with pass/fail evidence.
+4. Validate changed paths against the request policy.
+5. Stage and commit worker changes from the parent scheduler process.
+6. Create a PR if the runner and commit succeed.
+7. Build and persist a validated `AgentResult` bundle.
+8. Complete the queue item with pass/fail evidence.
+
+The parent scheduler owns `git add` and `git commit` because child Codex
+workers run in a workspace-write sandbox that may edit files but should not
+depend on direct `.git` mutation.
 
 `runQueueDaemon` repeats the same path for queued work with bounded polling,
 claim leases, heartbeats, and stop predicates.

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -301,6 +301,15 @@ export interface PullRequestExecution {
   command: CommandRunResult
 }
 
+interface WorkerCommitExecution {
+  requestId: string
+  branchName: string
+  status: 'committed' | 'failed'
+  commands: CommandRunResult[]
+  changedPaths: string[]
+  failedCommand?: string
+}
+
 export interface SingleAgentRunOptions {
   queue: JsonlAgentQueue
   repoRoot: string
@@ -882,6 +891,109 @@ export async function writeAgentResultBundle(
   return manifest
 }
 
+async function executeWorkerCommit(
+  request: AgentRequest,
+  execution: CodexRunnerExecution,
+  options: {
+    repoRoot: string
+    executor?: CommandExecutor
+    fallbackChangedPaths: string[]
+  },
+): Promise<WorkerCommitExecution> {
+  const executor = options.executor ?? createProcessCommandExecutor()
+  const commands: CommandRunResult[] = []
+  const statusCommand: RunnerCommand = {
+    command: 'git',
+    args: ['status', '--porcelain'],
+    cwd: options.repoRoot,
+  }
+  const status = await executor(statusCommand)
+  commands.push(status)
+
+  if (status.exitCode !== 0) {
+    return {
+      requestId: request.id,
+      branchName: execution.branchName,
+      status: 'failed',
+      commands,
+      changedPaths: [],
+      failedCommand: stringifyCommand(statusCommand),
+    }
+  }
+
+  let changedPaths = parseGitStatusChangedPaths(status.stdout)
+  if (changedPaths.length === 0 && status.stdout.startsWith('dry-run:')) {
+    changedPaths = [...options.fallbackChangedPaths]
+  }
+
+  if (changedPaths.length === 0) {
+    return {
+      requestId: request.id,
+      branchName: execution.branchName,
+      status: 'failed',
+      commands,
+      changedPaths,
+      failedCommand: 'worker produced no git changes',
+    }
+  }
+
+  const blockedPaths = changedPaths.filter((path) => !isAllowedWorkerPath(path, request.policy.allowedPaths))
+  if (blockedPaths.length > 0) {
+    return {
+      requestId: request.id,
+      branchName: execution.branchName,
+      status: 'failed',
+      commands,
+      changedPaths,
+      failedCommand: `worker changed paths outside policy: ${blockedPaths.join(', ')}`,
+    }
+  }
+
+  const addCommand: RunnerCommand = {
+    command: 'git',
+    args: ['add', '--', ...changedPaths],
+    cwd: options.repoRoot,
+  }
+  const add = await executor(addCommand)
+  commands.push(add)
+  if (add.exitCode !== 0) {
+    return {
+      requestId: request.id,
+      branchName: execution.branchName,
+      status: 'failed',
+      commands,
+      changedPaths,
+      failedCommand: stringifyCommand(addCommand),
+    }
+  }
+
+  const commitCommand: RunnerCommand = {
+    command: 'git',
+    args: ['commit', '-m', `[Factory] ${request.id}`],
+    cwd: options.repoRoot,
+  }
+  const commit = await executor(commitCommand)
+  commands.push(commit)
+  if (commit.exitCode !== 0) {
+    return {
+      requestId: request.id,
+      branchName: execution.branchName,
+      status: 'failed',
+      commands,
+      changedPaths,
+      failedCommand: stringifyCommand(commitCommand),
+    }
+  }
+
+  return {
+    requestId: request.id,
+    branchName: execution.branchName,
+    status: 'committed',
+    commands,
+    changedPaths,
+  }
+}
+
 export function planPullRequest(
   requestInput: unknown,
   execution: CodexRunnerExecution,
@@ -1004,7 +1116,41 @@ export async function runClaimedAgentRequest(
   let pullRequest: PullRequestExecution | undefined
 
   if (execution.status === 'completed') {
-    const prPlan = planPullRequest(claimed, execution, { repoRoot: options.repoRoot })
+    const commitOptions: Parameters<typeof executeWorkerCommit>[2] = {
+      repoRoot: options.repoRoot,
+      fallbackChangedPaths: options.changedFiles ?? claimed.expectedArtifacts.map((artifact) => artifact.path),
+    }
+    if (options.pullRequestExecutor) commitOptions.executor = options.pullRequestExecutor
+    const commit = await executeWorkerCommit(claimed, execution, commitOptions)
+
+    resultExecution = {
+      requestId: execution.requestId,
+      branchName: execution.branchName,
+      status: commit.status === 'committed' ? 'completed' : 'failed',
+      commands: [...execution.commands, ...commit.commands],
+      ...(commit.status === 'failed' ? { failedCommand: commit.failedCommand ?? 'worker commit' } : {}),
+    }
+
+    if (resultExecution.status !== 'completed') {
+      const resultOptions: AgentResultFromExecutionOptions = {
+        resultId: options.resultId,
+        agentRunId: options.agentRunId,
+        completedAt: options.completedAt,
+        artifactBasePath: options.bundleDir,
+      }
+      if (options.changedFiles) resultOptions.changedFiles = options.changedFiles
+
+      const result = buildAgentResultFromExecution(claimed, resultExecution, resultOptions)
+      const bundleOptions: AgentResultBundleOptions = {
+        bundleDir: options.bundleDir,
+      }
+      if (options.diff !== undefined) bundleOptions.diff = options.diff
+      const bundle = await writeAgentResultBundle(claimed, resultExecution, result, bundleOptions)
+      await options.queue.complete(result)
+      return { request: claimed, execution: resultExecution, result, bundle }
+    }
+
+    const prPlan = planPullRequest(claimed, resultExecution, { repoRoot: options.repoRoot })
     try {
       pullRequest = await executePullRequestPlan(prPlan, options.pullRequestExecutor)
     } catch (error) {
@@ -1015,7 +1161,7 @@ export async function runClaimedAgentRequest(
         requestId: execution.requestId,
         branchName: execution.branchName,
         status: 'failed',
-        commands: [...execution.commands, ...error.commands],
+        commands: [...resultExecution.commands, ...error.commands],
         failedCommand: 'pull request creation',
       }
     }
@@ -1738,6 +1884,42 @@ function redactCommandArgs(command: RunnerCommand): string[] {
     args[args.length - 1] = '<prompt omitted>'
   }
   return args
+}
+
+function parseGitStatusChangedPaths(output: string): string[] {
+  const paths = new Set<string>()
+  for (const line of output.split('\n')) {
+    if (line.trim().length === 0 || line.startsWith('dry-run:')) continue
+    const pathspec = (line[2] === ' ' ? line.slice(3) : line.replace(/^.{1,2}\s+/, '')).trim()
+    if (!pathspec) continue
+
+    if (pathspec.includes(' -> ')) {
+      const [from, to] = pathspec.split(' -> ').map((entry) => entry.trim())
+      if (from) paths.add(from)
+      if (to) paths.add(to)
+      continue
+    }
+
+    paths.add(pathspec)
+  }
+
+  return [...paths].sort()
+}
+
+function isAllowedWorkerPath(path: string, allowedPaths: readonly string[]): boolean {
+  return allowedPaths.some((pattern) => {
+    if (pattern.endsWith('/**')) {
+      return path.startsWith(pattern.slice(0, -3))
+    }
+
+    if (pattern.endsWith('/*')) {
+      const prefix = pattern.slice(0, -1)
+      if (!path.startsWith(prefix)) return false
+      return !path.slice(prefix.length).includes('/')
+    }
+
+    return path === pattern
+  })
 }
 
 function defaultExecutionSummary(request: AgentRequest, execution: CodexRunnerExecution): string {

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -678,16 +678,7 @@ describe('single-request scheduler run', () => {
           completedAt: '2026-04-30T14:30:01.000Z',
         }
       },
-      pullRequestExecutor: async (command) => ({
-        command: command.command,
-        args: command.args,
-        cwd: command.cwd,
-        exitCode: 0,
-        stdout: 'https://github.com/Wescome/strategy-recipes/pull/5\n',
-        stderr: '',
-        startedAt: '2026-04-30T14:36:00.000Z',
-        completedAt: '2026-04-30T14:36:01.000Z',
-      }),
+      pullRequestExecutor: successfulGitHubExecutor('https://github.com/Wescome/strategy-recipes/pull/5\n'),
     })
 
     expect(codexCommands).toEqual(['git', 'git', 'git', 'codex'])
@@ -837,7 +828,11 @@ describe('single-request scheduler run', () => {
         args: command.args,
         cwd: command.cwd,
         exitCode: command.command === 'gh' ? 1 : 0,
-        stdout: command.command === 'gh' ? '' : 'pushed',
+        stdout: command.command === 'gh'
+          ? ''
+          : command.args.includes('--porcelain')
+            ? 'M docs/product/first-product-view.md\n'
+            : 'pushed',
         stderr: command.command === 'gh' ? 'no commits' : '',
         startedAt: '2026-04-30T14:36:00.000Z',
         completedAt: '2026-04-30T14:36:01.000Z',
@@ -846,7 +841,17 @@ describe('single-request scheduler run', () => {
 
     expect(outcome.result.status).toBe('failed')
     expect(outcome.execution.failedCommand).toBe('pull request creation')
-    expect(outcome.execution.commands.map((command) => command.command)).toEqual(['git', 'git', 'git', 'codex', 'git', 'gh'])
+    expect(outcome.execution.commands.map((command) => command.command)).toEqual([
+      'git',
+      'git',
+      'git',
+      'codex',
+      'git',
+      'git',
+      'git',
+      'git',
+      'gh',
+    ])
     expect(readFileSync(outcome.bundle.files.result, 'utf8')).toContain('ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-PR-FAILED')
     expect(await queue.status()).toMatchObject({ total: 1, failed: 1 })
   })
@@ -879,16 +884,7 @@ describe('queue daemon', () => {
         startedAt: '2026-04-30T14:30:00.000Z',
         completedAt: '2026-04-30T14:30:01.000Z',
       }),
-      pullRequestExecutor: async (command) => ({
-        command: command.command,
-        args: command.args,
-        cwd: command.cwd,
-        exitCode: 0,
-        stdout: 'https://github.com/Wescome/strategy-recipes/pull/7\n',
-        stderr: '',
-        startedAt: '2026-04-30T14:36:00.000Z',
-        completedAt: '2026-04-30T14:36:01.000Z',
-      }),
+      pullRequestExecutor: successfulGitHubExecutor('https://github.com/Wescome/strategy-recipes/pull/7\n'),
     })
 
     expect(outcome).toEqual({
@@ -971,4 +967,21 @@ function expectValidationIssues(action: () => unknown, expectedIssues: string[])
 
 function fixedClock(): () => Date {
   return () => new Date('2026-04-30T14:30:00.000Z')
+}
+
+function successfulGitHubExecutor(prUrl: string) {
+  return async (command: { command: string; args: string[]; cwd: string }) => ({
+    command: command.command,
+    args: command.args,
+    cwd: command.cwd,
+    exitCode: 0,
+    stdout: command.command === 'gh'
+      ? prUrl
+      : command.args.includes('--porcelain')
+        ? 'M docs/product/first-product-view.md\n'
+        : 'ok\n',
+    stderr: '',
+    startedAt: '2026-04-30T14:36:00.000Z',
+    completedAt: '2026-04-30T14:36:01.000Z',
+  })
 }


### PR DESCRIPTION
## Summary
- add parent-owned `git status`, changed-path policy validation, `git add`, and `git commit` after successful child Codex execution
- fail closed when a worker produces no changes or touches paths outside the request policy
- keep child Codex sandboxed while allowing the scheduler to own branch commits before push/PR
- document the parent-owned commit boundary

## Dogfood Evidence
- Strategy.Recipes PR #69 exposed the gap: child Codex edited files but could not write `.git/index.lock`
- Parent operator salvaged the PR; this change makes that step scheduler-owned

## Validation
- `pnpm run autonomous-scheduler:test`
- `pnpm run autonomous-scheduler:typecheck`
- `pnpm run autonomous-scheduler:cli -- dogfood-strategy-recipes --repo-root /Users/wes/Developer/strategy-recipes --home /tmp/factory-dogfood-commit-XXXXXX`
