### PR TITLE
Target GitHub PR creation repo explicitly

### DIFF
--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -1011,6 +1011,7 @@ export function planPullRequest(
 
   const title = options.title ?? `[Factory] ${request.objective}`
   const body = options.body ?? buildPullRequestBody(request, execution)
+  const repoSpecifier = request.repo.owner ? `${request.repo.owner}/${request.repo.name}` : request.repo.name
 
   return {
     requestId: request.id,
@@ -1027,6 +1028,8 @@ export function planPullRequest(
       args: [
         'pr',
         'create',
+        '--repo',
+        repoSpecifier,
         '--base',
         request.branch.base,
         '--head',

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -448,7 +448,7 @@ describe('Codex runner planning', () => {
       cwd: '/tmp/strategy-recipes',
     })
     expect(prPlan.command.command).toBe('gh')
-    expect(prPlan.command.args.slice(0, 3)).toEqual(['pr', 'create', '--base'])
+    expect(prPlan.command.args.slice(0, 4)).toEqual(['pr', 'create', '--repo', 'Wescome/strategy-recipes'])
     expect(prPlan.command.args).toContain('main')
     expect(prPlan.command.args).toContain('factory/strategy-recipes-first-product-view/ar-strategy-recipes-first-product-view')
     expect(prPlan.body).toContain('Factory request: AR-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW')


### PR DESCRIPTION
## Summary
- add `--repo owner/name` to scheduler-generated `gh pr create` commands
- keep tests aligned with explicit repo targeting

## Dogfood Evidence
- Strategy.Recipes PR #70 showed parent commit and push now work
- PR creation still failed when `gh` inferred the upstream repo from local context

## Validation
- `pnpm run autonomous-scheduler:test`
- `pnpm run autonomous-scheduler:typecheck`
