### PR TITLE
Capture parent verification evidence

### DIFF
--- a/docs/STRATEGY_RECIPES_DOGFOOD.md
+++ b/docs/STRATEGY_RECIPES_DOGFOOD.md
@@ -61,3 +61,45 @@ pnpm run autonomous-scheduler:cli -- dogfood-strategy-recipes \
   --request /path/to/request.json \
   --repo-root /path/to/strategy-recipes
 ```
+
+## 2026-04-30 Real Dogfood Proof
+
+The scheduler completed a real Strategy.Recipes dogfood run for:
+
+```text
+AR-STRATEGY-RECIPES-DOGFOOD-EVIDENCE
+```
+
+The run produced, pushed, and opened Strategy.Recipes PR #71:
+
+```text
+https://github.com/Wescome/strategy-recipes/pull/71
+```
+
+The PR was squash-merged after parent-environment verification and the local
+Strategy.Recipes checkout was fast-forwarded to `main`.
+
+Evidence bundle:
+
+```text
+/tmp/factory-dogfood-evidence/strategy-recipes/strategy-recipes-20260430T214225017Z/bundle
+```
+
+Parent verification completed successfully on the PR branch:
+
+```text
+pnpm --dir packages/strategy-objects test      # pass, 5/5
+pnpm --dir packages/strategy-objects typecheck # pass
+npm run test:strategy-recipes                  # pass, 127/127
+```
+
+The child Codex worker reported a sandbox limitation while attempting local
+network-backed tests (`listen EPERM 127.0.0.1`) and could not mutate `.git`
+directly from its sandbox. The parent scheduler still completed the intended
+production-alpha boundary: parent-owned commit, push, PR creation, and
+independent verification.
+
+Follow-up hardening from this proof: the scheduler now reruns
+`requiredCommands` from the parent process after committing worker changes and
+before pushing the PR branch. Those commands are captured as
+`verification_output` evidence in each result bundle.

--- a/packages/autonomous-scheduler/README.md
+++ b/packages/autonomous-scheduler/README.md
@@ -39,13 +39,22 @@ also planned and executed through the same command seam using `gh pr create`.
 3. Execute the Codex runner plan.
 4. Validate changed paths against the request policy.
 5. Stage and commit worker changes from the parent scheduler process.
-6. Create a PR if the runner and commit succeed.
-7. Build and persist a validated `AgentResult` bundle.
-8. Complete the queue item with pass/fail evidence.
+6. Run every `requiredCommands` entry from the parent scheduler process.
+7. Create a PR only if the runner, commit, and parent verification succeed.
+8. Build and persist a validated `AgentResult` bundle.
+9. Complete the queue item with pass/fail evidence.
 
 The parent scheduler owns `git add` and `git commit` because child Codex
 workers run in a workspace-write sandbox that may edit files but should not
 depend on direct `.git` mutation.
+
+The parent scheduler also owns final verification. Child Codex workers still
+receive the required commands in their prompt, but the scheduler reruns those
+commands after the parent commit and before `git push` / `gh pr create`.
+Verification failures stop publication, complete the queue item as failed, and
+write `verification-output.txt` plus command-level output files into the result
+bundle. This makes parent-observed tests and typechecks first-class evidence
+rather than relying on child-session stdout.
 
 `runQueueDaemon` repeats the same path for queued work with bounded polling,
 claim leases, heartbeats, and stop predicates.

--- a/packages/autonomous-scheduler/src/index.ts
+++ b/packages/autonomous-scheduler/src/index.ts
@@ -37,6 +37,7 @@ export const EVIDENCE_KINDS = [
   'git_diff',
   'test_output',
   'typecheck_output',
+  'verification_output',
   'artifact_paths',
   'pr_url',
   'review_report',
@@ -58,6 +59,7 @@ export type BranchMode = (typeof BRANCH_MODES)[number]
 export type ForbiddenAction = (typeof FORBIDDEN_ACTIONS)[number]
 export type EvidenceKind = (typeof EVIDENCE_KINDS)[number]
 export type QueueEventType = (typeof QUEUE_EVENT_TYPES)[number]
+export type CommandRunPhase = 'preflight' | 'codex' | 'commit' | 'verification' | 'pull_request'
 type NonEmptyReadonlyArray<T> = readonly [T, ...T[]]
 
 export interface WorkGraphHandle {
@@ -224,6 +226,7 @@ export interface CommandRunResult {
   completedAt: string
   timedOut?: boolean
   signal?: string
+  phase?: CommandRunPhase
 }
 
 export interface CodexRunnerExecution {
@@ -275,6 +278,7 @@ export interface AgentResultBundleManifest {
     manifest: string
     commands: string[]
     diff?: string
+    verification?: string
   }
 }
 
@@ -299,6 +303,12 @@ export interface PullRequestExecution {
   prUrl: string
   commands: CommandRunResult[]
   command: CommandRunResult
+}
+
+export interface RequiredCommandExecutionOptions {
+  repoRoot: string
+  executor?: CommandExecutor
+  shell?: string
 }
 
 interface WorkerCommitExecution {
@@ -768,6 +778,14 @@ export function buildAgentResultFromExecution(
     })
   }
 
+  if (execution.commands.some((command) => command.phase === 'verification')) {
+    evidence.push({
+      kind: 'verification_output',
+      path: join(options.artifactBasePath, 'verification-output.txt'),
+      summary: 'Parent scheduler verification output captured after commit and before PR publication.',
+    })
+  }
+
   if (execution.status === 'completed') {
     evidence.push({
       kind: 'git_diff',
@@ -869,6 +887,17 @@ export async function writeAgentResultBundle(
     await writeFile(diffPath, options.diff, 'utf8')
   }
 
+  let verificationPath: string | undefined
+  const verificationCommands = execution.commands.filter((command) => command.phase === 'verification')
+  if (verificationCommands.length > 0) {
+    verificationPath = join(options.bundleDir, 'verification-output.txt')
+    await writeFile(
+      verificationPath,
+      verificationCommands.map((command) => formatCommandOutput(command)).join('\n---\n'),
+      'utf8',
+    )
+  }
+
   const manifest: AgentResultBundleManifest = {
     schemaVersion: 'factory.agent-result-bundle.v0',
     requestId: request.id,
@@ -885,6 +914,10 @@ export async function writeAgentResultBundle(
 
   if (diffPath) {
     manifest.files.diff = diffPath
+  }
+
+  if (verificationPath) {
+    manifest.files.verification = verificationPath
   }
 
   await writeJsonFile(manifestPath, manifest)
@@ -1086,6 +1119,25 @@ export async function executePullRequestPlan(
   }
 }
 
+export async function executeRequiredCommands(
+  requestInput: unknown,
+  options: RequiredCommandExecutionOptions,
+): Promise<CommandRunResult[]> {
+  const request = validateAgentRequest(requestInput)
+  const executor = options.executor ?? createProcessCommandExecutor()
+  const commands: CommandRunResult[] = []
+
+  for (const requiredCommand of request.requiredCommands) {
+    const command = buildRequiredCommand(requiredCommand, options)
+    const result = await executor(command)
+    commands.push({ ...result, phase: 'verification' })
+
+    if (result.exitCode !== 0) break
+  }
+
+  return commands
+}
+
 export async function runSingleAgentRequest(
   requestInput: unknown,
   options: SingleAgentRunOptions,
@@ -1132,6 +1184,40 @@ export async function runClaimedAgentRequest(
       status: commit.status === 'committed' ? 'completed' : 'failed',
       commands: [...execution.commands, ...commit.commands],
       ...(commit.status === 'failed' ? { failedCommand: commit.failedCommand ?? 'worker commit' } : {}),
+    }
+
+    if (resultExecution.status !== 'completed') {
+      const resultOptions: AgentResultFromExecutionOptions = {
+        resultId: options.resultId,
+        agentRunId: options.agentRunId,
+        completedAt: options.completedAt,
+        artifactBasePath: options.bundleDir,
+      }
+      if (options.changedFiles) resultOptions.changedFiles = options.changedFiles
+
+      const result = buildAgentResultFromExecution(claimed, resultExecution, resultOptions)
+      const bundleOptions: AgentResultBundleOptions = {
+        bundleDir: options.bundleDir,
+      }
+      if (options.diff !== undefined) bundleOptions.diff = options.diff
+      const bundle = await writeAgentResultBundle(claimed, resultExecution, result, bundleOptions)
+      await options.queue.complete(result)
+      return { request: claimed, execution: resultExecution, result, bundle }
+    }
+
+    const verification = await executeRequiredCommands(claimed, {
+      repoRoot: options.repoRoot,
+      ...(options.pullRequestExecutor ? { executor: options.pullRequestExecutor } : {}),
+    })
+    const failedVerification = verification.find((command) => command.exitCode !== 0)
+    resultExecution = {
+      requestId: execution.requestId,
+      branchName: execution.branchName,
+      status: failedVerification ? 'failed' : 'completed',
+      commands: [...resultExecution.commands, ...verification],
+      ...(failedVerification
+        ? { failedCommand: `parent verification: ${stringifyCommand(failedVerification)}` }
+        : {}),
     }
 
     if (resultExecution.status !== 'completed') {
@@ -1878,6 +1964,32 @@ function buildBranchName(request: AgentRequest, suffix?: string): string {
 
 function stringifyCommand(command: RunnerCommand): string {
   return [command.command, ...redactCommandArgs(command)].join(' ')
+}
+
+function buildRequiredCommand(command: string, options: RequiredCommandExecutionOptions): RunnerCommand {
+  return {
+    command: options.shell ?? process.env.SHELL ?? 'sh',
+    args: ['-lc', command],
+    cwd: options.repoRoot,
+  }
+}
+
+function formatCommandOutput(command: CommandRunResult): string {
+  return [
+    `$ ${stringifyCommand(command)}`,
+    '',
+    `exitCode: ${command.exitCode}`,
+    `cwd: ${command.cwd}`,
+    `startedAt: ${command.startedAt}`,
+    `completedAt: ${command.completedAt}`,
+    '',
+    'stdout:',
+    command.stdout,
+    '',
+    'stderr:',
+    command.stderr,
+    '',
+  ].join('\n')
 }
 
 function redactCommandArgs(command: RunnerCommand): string[] {

--- a/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
+++ b/packages/autonomous-scheduler/test/autonomous-scheduler.test.ts
@@ -13,6 +13,7 @@ import {
   createDryRunCommandExecutor,
   executeCodexRunnerPlan,
   executePullRequestPlan,
+  executeRequiredCommands,
   planCodexRunner,
   planPullRequest,
   runQueueDaemon,
@@ -308,6 +309,33 @@ describe('Codex runner planning', () => {
     expect(execution.status).toBe('completed')
     expect(execution.commands[0]?.stdout).toContain('dry-run: git fetch')
     expect(pr.prUrl).toBe('https://github.com/Wescome/strategy-recipes/pull/dry-run')
+  })
+
+  it('runs required commands as parent verification and stops on first failure', async () => {
+    const seen: string[] = []
+    const verification = await executeRequiredCommands(requestFixture, {
+      repoRoot: '/tmp/strategy-recipes',
+      shell: 'sh',
+      executor: async (command) => {
+        const requiredCommand = command.args.at(-1) ?? ''
+        seen.push(requiredCommand)
+        return {
+          command: command.command,
+          args: command.args,
+          cwd: command.cwd,
+          exitCode: requiredCommand === 'pnpm test' ? 1 : 0,
+          stdout: requiredCommand === 'pnpm test' ? '' : 'ok\n',
+          stderr: requiredCommand === 'pnpm test' ? 'tests failed\n' : '',
+          startedAt: '2026-04-30T14:30:00.000Z',
+          completedAt: '2026-04-30T14:30:01.000Z',
+        }
+      },
+    })
+
+    expect(seen).toEqual(['pnpm install --frozen-lockfile', 'pnpm test'])
+    expect(verification).toHaveLength(2)
+    expect(verification.map((command) => command.phase)).toEqual(['verification', 'verification'])
+    expect(verification[1]?.exitCode).toBe(1)
   })
 
   it('builds a validated completed AgentResult from runner execution', async () => {
@@ -684,6 +712,10 @@ describe('single-request scheduler run', () => {
     expect(codexCommands).toEqual(['git', 'git', 'git', 'codex'])
     expect(outcome.result.status).toBe('completed')
     expect(outcome.pullRequest?.prUrl).toBe('https://github.com/Wescome/strategy-recipes/pull/5')
+    expect(outcome.execution.commands.filter((command) => command.phase === 'verification')).toHaveLength(3)
+    expect(outcome.result.evidence.map((entry) => entry.kind)).toContain('verification_output')
+    expect(outcome.bundle.files.verification).toBeDefined()
+    expect(readFileSync(outcome.bundle.files.verification ?? '', 'utf8')).toContain('pnpm test')
     expect(readFileSync(outcome.bundle.files.manifest, 'utf8')).toContain('factory.agent-result-bundle.v0')
     expect(await queue.status()).toMatchObject({
       total: 1,
@@ -741,6 +773,60 @@ describe('single-request scheduler run', () => {
       total: 1,
       failed: 1,
     })
+  })
+
+  it('blocks PR creation when parent verification fails', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'factory-autonomous-'))
+    const queue = new JsonlAgentQueue({
+      queueDir: join(home, 'queue'),
+      actor: 'factory-governor',
+      now: fixedClock(),
+    })
+    const parentCommands: string[] = []
+
+    const outcome = await runSingleAgentRequest(requestFixture, {
+      queue,
+      repoRoot: '/tmp/strategy-recipes',
+      bundleDir: join(home, 'bundle'),
+      resultId: 'ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-VERIFY-FAILED',
+      agentRunId: 'RUN-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-VERIFY-FAILED',
+      completedAt: '2026-04-30T14:40:00.000Z',
+      changedFiles: ['docs/product/first-product-view.md'],
+      codexExecutor: async (command) => ({
+        command: command.command,
+        args: command.args,
+        cwd: command.cwd,
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        startedAt: '2026-04-30T14:30:00.000Z',
+        completedAt: '2026-04-30T14:30:01.000Z',
+      }),
+      pullRequestExecutor: async (command) => {
+        const commandText = [command.command, ...command.args].join(' ')
+        parentCommands.push(commandText)
+        const requiredCommand = command.args.at(-1) ?? ''
+        return {
+          command: command.command,
+          args: command.args,
+          cwd: command.cwd,
+          exitCode: requiredCommand === 'pnpm test' ? 1 : 0,
+          stdout: command.args.includes('--porcelain') ? 'M docs/product/first-product-view.md\n' : 'ok\n',
+          stderr: requiredCommand === 'pnpm test' ? 'tests failed\n' : '',
+          startedAt: '2026-04-30T14:36:00.000Z',
+          completedAt: '2026-04-30T14:36:01.000Z',
+        }
+      },
+    })
+
+    expect(outcome.result.status).toBe('failed')
+    expect(outcome.execution.failedCommand).toContain('parent verification:')
+    expect(outcome.execution.commands.filter((command) => command.phase === 'verification')).toHaveLength(2)
+    expect(outcome.pullRequest).toBeUndefined()
+    expect(parentCommands.some((command) => command.includes('gh pr create'))).toBe(false)
+    expect(parentCommands.some((command) => command.includes('git push'))).toBe(false)
+    expect(outcome.result.evidence.map((entry) => entry.kind)).toContain('verification_output')
+    expect(await queue.status()).toMatchObject({ total: 1, failed: 1 })
   })
 
   it('completes the queue with a refused result when Codex refuses the request', async () => {
@@ -841,7 +927,8 @@ describe('single-request scheduler run', () => {
 
     expect(outcome.result.status).toBe('failed')
     expect(outcome.execution.failedCommand).toBe('pull request creation')
-    expect(outcome.execution.commands.map((command) => command.command)).toEqual([
+    const executedCommands = outcome.execution.commands.map((command) => command.command)
+    expect(executedCommands.slice(0, 7)).toEqual([
       'git',
       'git',
       'git',
@@ -849,9 +936,9 @@ describe('single-request scheduler run', () => {
       'git',
       'git',
       'git',
-      'git',
-      'gh',
     ])
+    expect(outcome.execution.commands.filter((command) => command.phase === 'verification')).toHaveLength(3)
+    expect(executedCommands.slice(-2)).toEqual(['git', 'gh'])
     expect(readFileSync(outcome.bundle.files.result, 'utf8')).toContain('ARES-STRATEGY-RECIPES-FIRST-PRODUCT-VIEW-PR-FAILED')
     expect(await queue.status()).toMatchObject({ total: 1, failed: 1 })
   })


### PR DESCRIPTION
## Summary
- rerun AgentRequest requiredCommands from the parent scheduler after commit and before PR publication
- block PR creation when parent verification fails and persist verification-output.txt in result bundles
- record Strategy.Recipes PR #71 dogfood evidence and parent verification results

## Verification
- pnpm run autonomous-scheduler:test
- pnpm run autonomous-scheduler:typecheck