### PR TITLE
Stabilize workspace verification checks

### DIFF
--- a/packages/function-synthesis/src/run-live-synthesis.ts
+++ b/packages/function-synthesis/src/run-live-synthesis.ts
@@ -24,7 +24,7 @@ function parseSimpleYaml(text: string): Record<string, unknown> {
   const result: Record<string, unknown> = {}
   const lines = text.split("\n")
   let currentKey = ""
-  let currentArray: Record<string, unknown>[] = []
+  let currentArray: Array<Record<string, unknown> | string> = []
   let currentObj: Record<string, unknown> = {}
   let inArray = false
 

--- a/packages/gdk-agent/package.json
+++ b/packages/gdk-agent/package.json
@@ -13,7 +13,7 @@
     "clean": "shx rm -rf dist",
     "build": "tsgo -p tsconfig.build.json",
     "dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
-    "test": "vitest --run",
+    "test": "vitest --run --passWithNoTests",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "dependencies": {

--- a/packages/gdk-ai/package.json
+++ b/packages/gdk-ai/package.json
@@ -68,7 +68,7 @@
 		"build": "npm run generate-models && tsgo -p tsconfig.build.json",
 		"dev": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
 		"dev:tsc": "tsgo -p tsconfig.build.json --watch --preserveWatchOutput",
-		"test": "vitest --run",
+		"test": "vitest --run --passWithNoTests",
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {

--- a/packages/ontology-loader/src/index.test.ts
+++ b/packages/ontology-loader/src/index.test.ts
@@ -263,7 +263,7 @@ describe('seedOntology', () => {
     await seedOntology(db as any)
 
     const classeSaves = db.save.mock.calls.filter(
-      ([coll]: [string]) => coll === 'ontology_classes'
+      ([coll]) => coll === 'ontology_classes'
     )
     expect(classeSaves.length).toBe(ONTOLOGY_CLASSES.length)
   })
@@ -273,7 +273,7 @@ describe('seedOntology', () => {
     await seedOntology(db as any)
 
     const constraintSaves = db.save.mock.calls.filter(
-      ([coll]: [string]) => coll === 'ontology_constraints'
+      ([coll]) => coll === 'ontology_constraints'
     )
     expect(constraintSaves.length).toBe(ONTOLOGY_CONSTRAINTS.length)
   })
@@ -284,7 +284,7 @@ describe('seedOntology', () => {
     db.save = vi.fn(async () => {
       callCount++
       if (callCount === 3) throw new Error('unique constraint violated')
-      return { _key: 'test' }
+      return { _key: 'test', _id: 'mock/test' }
     })
 
     // Should not throw

--- a/packages/task-routing/src/index.test.ts
+++ b/packages/task-routing/src/index.test.ts
@@ -1,146 +1,48 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { resolve, resolveAndCall } from './index.js'
 import type { RoutingConfig } from './index.js'
 
-// ────────────────────────────────────────────────────────────
-// resolve() — basic kind resolution
-// ────────────────────────────────────────────────────────────
+const CF_70B = '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
+const CF_KIMI = '@cf/moonshotai/kimi-k2.6'
 
 describe('resolve', () => {
-  it('returns primary + fallback for a known task kind', () => {
-    const route = resolve('planner')
-    expect(route.primary.provider).toBe('google')
-    expect(route.primary.model).toBe('gemini-3.1-pro-preview')
-    expect(route.fallback?.provider).toBe('deepseek')
+  it('routes pipeline task kinds to Workers AI llama 70B by default', () => {
+    for (const kind of ['planning', 'structured', 'interpretive', 'synthesis', 'validation', 'runtime_check', 'semantic_review'] as const) {
+      const route = resolve(kind)
+      expect(route.primary).toEqual({ provider: 'cloudflare', model: CF_70B })
+      expect(route.fallback).toBeUndefined()
+      expect(route.resolvedVia).toBe('route-default')
+    }
+  })
+
+  it('routes stage 6 agent roles to Workers AI Kimi with llama fallback', () => {
+    for (const kind of ['planner', 'coder', 'critic', 'tester', 'verifier'] as const) {
+      const route = resolve(kind)
+      expect(route.primary).toEqual({ provider: 'cloudflare', model: CF_KIMI })
+      expect(route.fallback).toEqual({ provider: 'cloudflare', model: CF_70B })
+      expect(route.resolvedVia).toBe('route-default')
+    }
+  })
+
+  it('does not invent default pass overrides', () => {
+    const route = resolve('planning', { passId: 'stage_2_pressure' })
+    expect(route.primary).toEqual({ provider: 'cloudflare', model: CF_70B })
+    expect(route.passId).toBeUndefined()
     expect(route.resolvedVia).toBe('route-default')
   })
 
-  it('returns config default when task kind has no explicit route', () => {
+  it('returns config default when the supplied config has no explicit route', () => {
     const sparse: RoutingConfig = {
       routes: [],
       default: { provider: 'deepseek', model: 'deepseek-v4-flash' },
     }
     const route = resolve('planning', { config: sparse })
-    expect(route.primary.provider).toBe('deepseek')
-    expect(route.primary.model).toBe('deepseek-v4-flash')
+    expect(route.primary).toEqual({ provider: 'deepseek', model: 'deepseek-v4-flash' })
     expect(route.fallback).toBeUndefined()
     expect(route.resolvedVia).toBe('config-default')
   })
 
-  // ── Pass-level overrides ──
-
-  it('resolves pass override for stage_2_pressure', () => {
-    const route = resolve('planning', { passId: 'stage_2_pressure' })
-    expect(route.primary.provider).toBe('deepseek')
-    expect(route.primary.model).toBe('deepseek-v4-pro')
-    expect(route.fallback?.provider).toBe('google')
-    expect(route.resolvedVia).toBe('pass-override')
-    expect(route.passId).toBe('stage_2_pressure')
-  })
-
-  it('resolves pass override for stage_3_capability', () => {
-    const route = resolve('planning', { passId: 'stage_3_capability' })
-    expect(route.primary.provider).toBe('google')
-    expect(route.primary.model).toBe('gemini-3.1-pro-preview')
-    expect(route.resolvedVia).toBe('pass-override')
-  })
-
-  it('resolves pass override for pass_3_invariants', () => {
-    const route = resolve('structured', { passId: 'pass_3_invariants' })
-    expect(route.primary.provider).toBe('z-ai')
-    expect(route.primary.model).toBe('glm-5')
-    expect(route.fallback?.provider).toBe('deepseek')
-    expect(route.fallback?.model).toBe('deepseek-v4-pro')
-    expect(route.resolvedVia).toBe('pass-override')
-  })
-
-  it('resolves pass override for pass_5_validations', () => {
-    const route = resolve('structured', { passId: 'pass_5_validations' })
-    expect(route.primary.provider).toBe('z-ai')
-    expect(route.primary.model).toBe('glm-5')
-    expect(route.resolvedVia).toBe('pass-override')
-  })
-
-  it('falls back to route default for unknown passId', () => {
-    const route = resolve('planning', { passId: 'nonexistent_pass' })
-    expect(route.primary.provider).toBe('deepseek')
-    expect(route.primary.model).toBe('deepseek-v4-flash')
-    expect(route.resolvedVia).toBe('route-default')
-  })
-
-  it('falls back to route default when no passId provided', () => {
-    const route = resolve('planning')
-    expect(route.primary.provider).toBe('deepseek')
-    expect(route.primary.model).toBe('deepseek-v4-flash')
-    expect(route.resolvedVia).toBe('route-default')
-  })
-
-  // ── Workers AI (cloudflare provider) ──
-
-  it('resolves stage_1_signal to Workers AI primary', () => {
-    const route = resolve('planning', { passId: 'stage_1_signal' })
-    expect(route.primary.provider).toBe('cloudflare')
-    expect(route.primary.model).toBe('@cf/qwen/qwen3-30b-a3b')
-    expect(route.fallback?.provider).toBe('deepseek')
-    expect(route.resolvedVia).toBe('pass-override')
-  })
-
-  it('uses Workers AI as fallback for validation tasks', () => {
-    const route = resolve('validation')
-    expect(route.primary.provider).toBe('deepseek')
-    expect(route.fallback?.provider).toBe('cloudflare')
-    expect(route.fallback?.model).toBe('@cf/qwen/qwen3-30b-a3b')
-  })
-
-  it('uses Workers AI as fallback for runtime_check tasks', () => {
-    const route = resolve('runtime_check')
-    expect(route.fallback?.provider).toBe('cloudflare')
-  })
-
-  // ── New TaskKinds: semantic_review and runtime_check ──
-
-  it('routes semantic_review to Opus', () => {
-    const route = resolve('semantic_review')
-    expect(route.primary.provider).toBe('anthropic')
-    expect(route.primary.model).toBe('claude-opus-4.6')
-    expect(route.fallback?.provider).toBe('google')
-  })
-
-  it('routes runtime_check to DeepSeek with cloudflare fallback', () => {
-    const route = resolve('runtime_check')
-    expect(route.primary.provider).toBe('deepseek')
-    expect(route.primary.model).toBe('deepseek-v4-flash')
-    expect(route.fallback?.provider).toBe('cloudflare')
-  })
-
-  // ── Stage 6 roles per April 2026 analysis ──
-
-  it('maps each stage 6 role correctly', () => {
-    const planner = resolve('planner')
-    expect(planner.primary.provider).toBe('google')
-
-    const coder = resolve('coder')
-    expect(coder.primary.provider).toBe('deepseek')
-    expect(coder.primary.model).toBe('deepseek-v4-pro')
-    expect(coder.fallback?.provider).toBe('anthropic')
-
-    const critic = resolve('critic')
-    expect(critic.primary.provider).toBe('anthropic')
-    expect(critic.primary.model).toBe('claude-opus-4.6')
-
-    const tester = resolve('tester')
-    expect(tester.primary.provider).toBe('deepseek')
-    expect(tester.fallback?.provider).toBe('moonshotai')
-    expect(tester.fallback?.model).toBe('kimi-k2.6')
-
-    const verifier = resolve('verifier')
-    expect(verifier.primary.provider).toBe('google')
-    expect(verifier.fallback?.provider).toBe('anthropic')
-  })
-
-  // ── Custom config ──
-
-  it('accepts a custom config', () => {
+  it('accepts a custom config route', () => {
     const custom: RoutingConfig = {
       routes: [
         {
@@ -151,128 +53,86 @@ describe('resolve', () => {
       default: { provider: 'deepseek', model: 'deepseek-v4-flash' },
     }
     const route = resolve('planning', { config: custom })
-    expect(route.primary.provider).toBe('cloudflare')
-    expect(route.primary.model).toBe('@cf/meta/llama-4-scout-17b-16e-instruct')
+    expect(route.primary).toEqual({ provider: 'cloudflare', model: '@cf/meta/llama-4-scout-17b-16e-instruct' })
+    expect(route.resolvedVia).toBe('route-default')
   })
 
-  // ── Fallback inheritance ──
-
-  it('pass override without fallback inherits route fallback', () => {
+  it('supports custom pass overrides and inherits route fallback when omitted', () => {
     const config: RoutingConfig = {
-      routes: [{
-        kind: 'planning',
-        primary: { provider: 'deepseek', model: 'deepseek-v4-flash' },
-        fallback: { provider: 'anthropic', model: 'claude-haiku-4.5' },
-        passOverrides: {
-          'my_pass': {
-            primary: { provider: 'google', model: 'gemini-3.1-pro-preview' },
-            // no fallback — should inherit route's fallback
+      routes: [
+        {
+          kind: 'planning',
+          primary: { provider: 'cloudflare', model: CF_70B },
+          fallback: { provider: 'cloudflare', model: CF_KIMI },
+          passOverrides: {
+            my_pass: {
+              primary: { provider: 'google', model: 'gemini-3.1-pro-preview' },
+            },
           },
         },
-      }],
-      default: { provider: 'deepseek', model: 'deepseek-v4-flash' },
+      ],
+      default: { provider: 'cloudflare', model: CF_70B },
     }
     const route = resolve('planning', { passId: 'my_pass', config })
-    expect(route.primary.provider).toBe('google')
-    expect(route.fallback?.provider).toBe('anthropic')  // inherited from route
+    expect(route.primary).toEqual({ provider: 'google', model: 'gemini-3.1-pro-preview' })
+    expect(route.fallback).toEqual({ provider: 'cloudflare', model: CF_KIMI })
+    expect(route.passId).toBe('my_pass')
+    expect(route.resolvedVia).toBe('pass-override')
   })
 
-  // ── Model ID correctness (ofox.ai catalog) ──
-
-  it('uses dots in claude-opus-4.6 (not hyphens)', () => {
-    const route = resolve('semantic_review')
-    expect(route.primary.model).toBe('claude-opus-4.6')
-    expect(route.primary.model).not.toContain('4-6')
-  })
-
-  it('uses -preview suffix for gemini', () => {
-    const route = resolve('interpretive')
-    expect(route.primary.model).toBe('gemini-3.1-pro-preview')
-  })
-
-  it('uses z-ai provider (not zhipu)', () => {
-    const route = resolve('structured', { passId: 'pass_3_invariants' })
-    expect(route.primary.provider).toBe('z-ai')
-    expect(route.primary.provider).not.toBe('zhipu')
-  })
-
-  it('uses moonshotai provider (not moonshot)', () => {
-    const route = resolve('tester')
-    expect(route.fallback?.provider).toBe('moonshotai')
-    expect(route.fallback?.provider).not.toBe('moonshot')
+  it('uses the current Workers AI model identifiers', () => {
+    expect(resolve('planning').primary.model).toBe(CF_70B)
+    expect(resolve('planner').primary.model).toBe(CF_KIMI)
   })
 })
 
-// ────────────────────────────────────────────────────────────
-// resolveAndCall() — primary + fallback execution
-// ────────────────────────────────────────────────────────────
-
 describe('resolveAndCall', () => {
-  it('calls fn with primary target on success', async () => {
+  it('calls fn with the primary target on success', async () => {
     const result = await resolveAndCall('planner', async (target) => {
       return `called ${target.provider}/${target.model}`
     })
-    expect(result).toBe('called google/gemini-3.1-pro-preview')
+    expect(result).toBe(`called cloudflare/${CF_KIMI}`)
   })
 
-  it('falls back on primary failure', async () => {
+  it('falls back when the primary target fails and a fallback exists', async () => {
     let attempt = 0
     const result = await resolveAndCall('planner', async (target) => {
-      attempt++
+      attempt += 1
       if (attempt === 1) throw new Error('primary down')
       return `called ${target.provider}/${target.model}`
     })
-    expect(result).toBe('called deepseek/deepseek-v4-pro')
+    expect(result).toBe(`called cloudflare/${CF_70B}`)
     expect(attempt).toBe(2)
   })
 
-  it('respects passId in resolveAndCall', async () => {
+  it('uses custom pass overrides during resolveAndCall', async () => {
+    const config: RoutingConfig = {
+      routes: [
+        {
+          kind: 'planning',
+          primary: { provider: 'cloudflare', model: CF_70B },
+          passOverrides: {
+            my_pass: {
+              primary: { provider: 'google', model: 'gemini-3.1-pro-preview' },
+            },
+          },
+        },
+      ],
+      default: { provider: 'cloudflare', model: CF_70B },
+    }
     const result = await resolveAndCall(
       'planning',
       async (target) => `called ${target.provider}/${target.model}`,
-      { passId: 'stage_2_pressure' },
+      { passId: 'my_pass', config },
     )
-    expect(result).toBe('called deepseek/deepseek-v4-pro')
-  })
-
-  it('falls back from pass override primary to pass override fallback', async () => {
-    let attempt = 0
-    const result = await resolveAndCall(
-      'planning',
-      async (target) => {
-        attempt++
-        if (attempt === 1) throw new Error('V4 Pro down')
-        return `called ${target.provider}/${target.model}`
-      },
-      { passId: 'stage_2_pressure' },
-    )
-    // stage_2_pressure fallback is google/gemini-3.1-pro-preview
     expect(result).toBe('called google/gemini-3.1-pro-preview')
   })
 
   it('throws if primary fails and no fallback exists', async () => {
-    const noFallback: RoutingConfig = {
-      routes: [{
-        kind: 'planning',
-        primary: { provider: 'openai', model: 'gpt-5.4' },
-      }],
-      default: { provider: 'deepseek', model: 'deepseek-v4-flash' },
-    }
     await expect(
-      resolveAndCall(
-        'planning',
-        async () => { throw new Error('down') },
-        { config: noFallback },
-      ),
+      resolveAndCall('planning', async () => {
+        throw new Error('down')
+      }),
     ).rejects.toThrow('down')
-  })
-
-  it('resolveAndCall with Workers AI primary', async () => {
-    const result = await resolveAndCall(
-      'planning',
-      async (target) => `called ${target.provider}/${target.model}`,
-      { passId: 'stage_1_signal' },
-    )
-    expect(result).toBe('called cloudflare/@cf/qwen/qwen3-30b-a3b')
   })
 })


### PR DESCRIPTION
## Summary
- Allow imported GDK packages with no local tests to pass Vitest workspace runs.
- Fix the live synthesis YAML parser type to match its mixed object/string array behavior.
- Update task-routing tests to assert the current v4 Workers AI routing policy instead of the stale multi-provider matrix.
- Fix ontology-loader test typings under strict workspace typechecking.

## Verification
- `pnpm --filter @weops/gdk-agent run test`
- `pnpm --filter @weops/gdk-ai run test`
- `pnpm --filter @factory/function-synthesis run test`
- `pnpm --filter @factory/function-synthesis run typecheck`
- `pnpm --filter @factory/task-routing run test && pnpm --filter @factory/task-routing run typecheck`
- `pnpm --filter @factory/ontology-loader run test && pnpm --filter @factory/ontology-loader run typecheck`
- `pnpm test`
- `pnpm -r --filter '!@factory/ff-pipeline' typecheck`\n\n## Remaining production gap\n- Full `pnpm typecheck` still fails in `@factory/ff-pipeline`; that is a larger worker-specific exact optional/property typing cleanup and is intentionally not bundled into this PR.\n\n## Worktree note\nUnrelated `.agent` files and an untracked `.github/workflows/ci.yml` are present locally and were not included.