### PR TITLE
[Factory] PR candidate: WG-MOPXR5H7-GWCC

### DIFF
--- a/workers/ff-pipeline/src/config/crystallizer-config.ts
+++ b/workers/ff-pipeline/src/config/crystallizer-config.ts
@@ -50,7 +50,7 @@ export async function seedPipelineConfig(
     await db.query(
       `UPSERT { _key: 'pipeline' }
        INSERT { _key: 'pipeline', crystallizer: @crystallizer, seededAt: @now, source: 'hardcoded-defaults' }
-       UPDATE { crystallizer: @crystallizer, seededAt: @now, source: 'hardcoded-defaults' }
+       UPDATE { seededAt: @now, source: 'hardcoded-defaults' }
        IN hot_config`,
       { crystallizer: { enabled: true }, now: new Date().toISOString() },
     )

--- a/workers/ff-pipeline/src/pipeline-update-test.ts
+++ b/workers/ff-pipeline/src/pipeline-update-test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { getPipelineUpsertAql } from './config/crystallizer-config';
+
+describe('AQL UPDATE clause crystallizer preservation', () => {
+  it('preserves operator-set crystallizer.enabled configuration during pipeline updates', () => {
+    const aql = getPipelineUpsertAql();
+
+    // The AQL string must contain an UPDATE statement.
+    expect(aql).toContain('UPDATE');
+
+    // Extract the inline object from the UPDATE clause.
+    // Expected shape after the fix: { seededAt: @now, source: hardcoded-defaults }
+    const updateMatch = aql.match(/UPDATE\s+({[^{}]+})/s);
+    expect(updateMatch).toBeTruthy();
+    const updateClause = updateMatch![1];
+
+    // The UPDATE clause should refresh seededAt and source...
+    expect(updateClause).toContain('seededAt: @now');
+    expect(updateClause).toContain('source: hardcoded-defaults');
+
+    // ...but must NOT include crystallizer so that an operator-set
+    // crystallizer.enabled value survives the upsert.
+    expect(updateClause).not.toContain('crystallizer:');
+    expect(aql).not.toMatch(/UPDATE\s+{[^}]*\bcrystallizer\s*:/s);
+  });
+});


### PR DESCRIPTION
## Factory-Generated PR

**WorkGraph:** `WG-MOPXR5H7-GWCC`
**Proposal:** `FP-MOPXH1D0-9F30`
**Confidence:** 0.95

### Lineage

- `SIG:SIG-MOPXGR8I-Z20X`
- `PRS:PRS-MOPXGRAE-5SJP`
- `BC:BC-MOPXGU0O-4M74`
- `FN:FP-MOPXH1D0-9F30`
- `WG:WG-MOPXR5H7-GWCC`

### Atom Results

- **atom-001** (pass): Updated the AQL UPDATE clause in crystallizer-config.ts to only set metadata fields (seededAt and source) on upsert, removing crystallizer: @crystallizer so that operator-set crystallizer.enabled configuration is preserved across pipeline updates. — 1 file(s)
- **atom-002** (pass): Modified seedPipelineConfig in crystallizer-config.ts so the AQL UPSERT UPDATE clause only touches seededAt and source, preserving any operator-set crystallizer.enabled value in the hot_config/pipeline document. — 1 file(s)
- **atom-004** (pass): Modified the AQL UPDATE clause in crystallizer-config.ts to omit the crystallizer field during upsert updates, ensuring operator-set crystallizer.enabled values are preserved instead of overwritten by hardcoded defaults. — 1 file(s)
- **atom-003** (pass): Created pipeline-update-test.ts to verify that the AQL UPDATE clause in crystallizer-config only updates seededAt and source, leaving operator-set crystallizer.enabled intact during pipeline upserts. — 1 file(s)

### Conflict Detection

- **PR created at:** `2026-05-03T15:43:20.499Z`

> **Warning:** The Factory generates code from a codebase snapshot. If the repo has diverged since the signal was created, file conflicts may exist. Review carefully before merging.

### Compile Gate

> Factory-generated PRs must pass CI typecheck before merging.
> If CI fails, this PR should be closed — the failure will feed back as a `synthesis:compile-failed` signal.

---
_Generated by the Function Factory feedback loop._