### PR TITLE
fix: ensureCollection in ingest-signal + robust init-db

### DIFF
--- a/workers/ff-pipeline/src/index.ts
+++ b/workers/ff-pipeline/src/index.ts
@@ -2720,19 +2720,25 @@ async function _initDb(env: PipelineEnv): Promise<Response> {
   const basicAuth = btoa(`${env.ARANGO_USERNAME ?? 'root'}:${env.ARANGO_PASSWORD ?? ''}`)
   const rootHeaders = { Authorization: `Basic ${basicAuth}`, 'Content-Type': 'application/json' }
 
-  // 1. Create database (idempotent — error 1207 = already exists)
-  const dbRes = await fetch(`${env.ARANGO_URL}/_api/database`, {
-    method: 'POST',
-    headers: rootHeaders,
-    body: JSON.stringify({ name: env.ARANGO_DATABASE }),
-  })
-  const dbBody = await dbRes.json() as Record<string, unknown>
-  if (dbRes.ok) {
-    results.push(`db:${env.ARANGO_DATABASE} created`)
-  } else if ((dbBody.errorNum as number) === 1207) {
-    results.push(`db:${env.ARANGO_DATABASE} exists`)
-  } else {
-    return json({ ok: false, error: `database create failed: ${JSON.stringify(dbBody)}`, results }, 500)
+  // 1. Create database (best-effort — skipped if Basic auth unavailable or DB already exists)
+  try {
+    const dbRes = await fetch(`${env.ARANGO_URL}/_api/database`, {
+      method: 'POST',
+      headers: rootHeaders,
+      body: JSON.stringify({ name: env.ARANGO_DATABASE }),
+    })
+    const dbText = await dbRes.text()
+    let dbBody: Record<string, unknown> = {}
+    try { dbBody = JSON.parse(dbText) } catch { /* non-JSON response — skip */ }
+    if (dbRes.ok) {
+      results.push(`db:${env.ARANGO_DATABASE} created`)
+    } else if ((dbBody.errorNum as number) === 1207) {
+      results.push(`db:${env.ARANGO_DATABASE} exists`)
+    } else {
+      results.push(`db:create skipped (${dbRes.status}: ${dbText.slice(0, 80)})`)
+    }
+  } catch (err) {
+    results.push(`db:create skipped (${err instanceof Error ? err.message : String(err)})`)
   }
 
   // 2. Ensure all collections

--- a/workers/ff-pipeline/src/pr-outcome-queue.test.ts
+++ b/workers/ff-pipeline/src/pr-outcome-queue.test.ts
@@ -48,6 +48,7 @@ const mockDb = {
   queryOne: vi.fn(async () => null),
   save: vi.fn(async (_collection: string, signal: Record<string, unknown>) => signal),
   setValidator: vi.fn(),
+  ensureCollection: vi.fn(async () => {}),
 }
 
 vi.mock('@factory/arango-client', () => ({

--- a/workers/ff-pipeline/src/stages/ingest-signal.ts
+++ b/workers/ff-pipeline/src/stages/ingest-signal.ts
@@ -15,6 +15,8 @@ export async function ingestSignal(
     )
   }
 
+  await db.ensureCollection('specs_signals')
+
   const idempotencyKey = computeIdempotencyKey(input)
 
   const existing = await db.queryOne<Record<string, unknown>>(

--- a/workers/ff-pipeline/src/stages/pr-outcome-signal.test.ts
+++ b/workers/ff-pipeline/src/stages/pr-outcome-signal.test.ts
@@ -190,6 +190,7 @@ describe('ingestPROutcomeSignals', () => {
     const db = {
       queryOne: vi.fn(async () => null),
       save: vi.fn(async (_collection: string, signal: Record<string, unknown>) => signal),
+      ensureCollection: vi.fn(async () => {}),
     }
 
     const records = await ingestPROutcomeSignals(makeInput(), db as never)

--- a/workers/ff-pipeline/src/stages/semantic-grounding.test.ts
+++ b/workers/ff-pipeline/src/stages/semantic-grounding.test.ts
@@ -65,6 +65,7 @@ function createMockDb() {
     saveEdge: vi.fn(async () => ({ _key: 'mock-edge' })),
     query: vi.fn(async () => []),
     queryOne: vi.fn(async () => null),
+    ensureCollection: vi.fn(async () => {}),
   }
 }
 

--- a/workers/ff-pipeline/src/stages/synthesize-pressure.ts
+++ b/workers/ff-pipeline/src/stages/synthesize-pressure.ts
@@ -65,6 +65,7 @@ export async function synthesizePressure(
 
   const pressure = {
     _key: key,
+    id: key,
     type: 'pressure',
     ...parsed,
     sourceSignalId: signal._key,


### PR DESCRIPTION
## Summary

- `ingestSignal` now calls `db.ensureCollection('specs_signals')` before querying, so the pipeline self-heals on first run without requiring `init-db` to pre-create the collection
- `_initDb` database-creation step is now best-effort: non-JSON responses (e.g. Cloudflare error 1016 when Basic auth is unavailable) are caught and logged, allowing the function to continue to `ensureCollection` for all doc/edge collections

## Test plan

- [ ] `POST /admin/init-db` returns `ok: true` with all collections listed
- [ ] Full pipeline run clears `ingest-signal` without error on a fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)