### PR TITLE
feat(d1): provision ff-factory D1 database and apply schema

### DIFF
--- a/workers/ff-gates/wrangler.jsonc
+++ b/workers/ff-gates/wrangler.jsonc
@@ -7,6 +7,6 @@
 
   // D1 Database
   "d1_databases": [
-    { "binding": "DB", "database_name": "ff-factory", "database_id": "REPLACE_WITH_OUTPUT_OF_wrangler_d1_create_ff-factory" }
+    { "binding": "DB", "database_name": "ff-factory", "database_id": "6a72d5c3-bcbb-41e3-b29d-d8de5834c3b3" }
   ]
 }

--- a/workers/ff-gateway/wrangler.jsonc
+++ b/workers/ff-gateway/wrangler.jsonc
@@ -7,7 +7,7 @@
 
   // D1 Database
   "d1_databases": [
-    { "binding": "DB", "database_name": "ff-factory", "database_id": "REPLACE_WITH_OUTPUT_OF_wrangler_d1_create_ff-factory" }
+    { "binding": "DB", "database_name": "ff-factory", "database_id": "6a72d5c3-bcbb-41e3-b29d-d8de5834c3b3" }
   ],
 
   // Service Bindings — internal Workers, no public route

--- a/workers/ff-pipeline/d1-schema.sql
+++ b/workers/ff-pipeline/d1-schema.sql
@@ -1,0 +1,29 @@
+-- Factory D1 Schema
+--
+-- Replaces ArangoDB's 48-collection model with two general-purpose tables:
+--   documents  — stores any JSON document addressed by (collection, key)
+--   edges      — stores directed relationships between documents within a collection
+--
+-- Both tables use IF NOT EXISTS so the schema is safe to apply idempotently.
+
+CREATE TABLE IF NOT EXISTS documents (
+    collection TEXT    NOT NULL,
+    key        TEXT    NOT NULL,
+    json       TEXT    NOT NULL,
+    created_at INTEGER DEFAULT (unixepoch()),
+    PRIMARY KEY (collection, key)
+);
+
+CREATE TABLE IF NOT EXISTS edges (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    collection TEXT    NOT NULL,
+    from_id    TEXT    NOT NULL,
+    to_id      TEXT    NOT NULL,
+    data       TEXT,
+    created_at INTEGER DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_documents_collection ON documents(collection);
+CREATE INDEX IF NOT EXISTS idx_edges_from           ON edges(collection, from_id);
+CREATE INDEX IF NOT EXISTS idx_edges_to             ON edges(collection, to_id);
+CREATE INDEX IF NOT EXISTS idx_edges_collection     ON edges(collection);

--- a/workers/ff-pipeline/wrangler.jsonc
+++ b/workers/ff-pipeline/wrangler.jsonc
@@ -42,7 +42,7 @@
 
   // D1 Database
   "d1_databases": [
-    { "binding": "DB", "database_name": "ff-factory", "database_id": "REPLACE_WITH_OUTPUT_OF_wrangler_d1_create_ff-factory" }
+    { "binding": "DB", "database_name": "ff-factory", "database_id": "6a72d5c3-bcbb-41e3-b29d-d8de5834c3b3" }
   ],
 
   // Service Bindings


### PR DESCRIPTION
## Summary

- Add `d1-schema.sql` — creates `documents` and `edges` tables with collection indexes
- Wire real D1 `database_id` (`6a72d5c3-bcbb-41e3-b29d-d8de5834c3b3`) into `ff-pipeline`, `ff-gates`, `ff-gateway` wrangler configs
- Database already provisioned and schema already applied to remote (`wrangler d1 execute --remote`)

## Test plan
- [ ] CI passes
- [ ] `wrangler d1 execute ff-factory --command "SELECT name FROM sqlite_master WHERE type='table'" --remote` returns `documents` and `edges`

🤖 Generated with [Claude Code](https://claude.com/claude-code)