### PR TITLE
fix(d1): port remaining AQL queries to SQL

### DIFF
--- a/packages/ontology-loader/src/index.test.ts
+++ b/packages/ontology-loader/src/index.test.ts
@@ -40,7 +40,9 @@ function createMockDb() {
   // query() returns { json: string }[] — same shape as D1 rows
   const query = vi.fn(async <T = unknown>(sql: string, params: unknown[] = []): Promise<T[]> => {
     if (sql.includes('ontology_constraints') && sql.includes('targetClasses')) {
-      const className = params[0] as string
+      // params[0] is a LIKE pattern like %ClassName% — strip wildcards for mock filtering
+      const raw = params[0] as string
+      const className = raw.replace(/%/g, '')
       const rows = Object.values(store['ontology_constraints'] ?? {})
       return rows
         .map(j => JSON.parse(j) as OntologyConstraint)

--- a/packages/ontology-loader/src/index.ts
+++ b/packages/ontology-loader/src/index.ts
@@ -175,10 +175,12 @@ export async function getConstraintsForClass(
   className: string,
 ): Promise<OntologyConstraint[]> {
   const rows = await db.query<{ json: string }>(
-    `SELECT d.json FROM documents d, json_each(json_extract(d.json,'$.targetClasses')) t WHERE d.collection='ontology_constraints' AND t.value=?`,
-    [className],
+    `SELECT json FROM documents WHERE collection='ontology_constraints' AND json_extract(json,'$.targetClasses') LIKE ?`,
+    [`%${className}%`],
   )
-  return rows.map(r => JSON.parse(r.json) as OntologyConstraint)
+  return rows
+    .map(r => JSON.parse(r.json) as OntologyConstraint)
+    .filter(c => Array.isArray(c.targetClasses) && c.targetClasses.includes(className))
 }
 
 /**

--- a/workers/ff-pipeline/src/compilers/formula-compiler-adapter.ts
+++ b/workers/ff-pipeline/src/compilers/formula-compiler-adapter.ts
@@ -22,10 +22,10 @@ export function buildFormulaCompilerDeps(
   WHERE collection='verification_reports'
     AND json_extract(json,'$.kind')='coherence'
     AND json_extract(json,'$.status')='passed'
-    AND EXISTS (SELECT 1 FROM json_each(json_extract(json,'$.source_refs')) WHERE value=?)
+    AND json_extract(json,'$.source_refs') LIKE ?
   ORDER BY json_extract(json,'$.created_at') DESC
   LIMIT 1`,
-        [esId],
+        [`%${esId}%`],
       )
       return row ? JSON.parse(row.json) as CoherenceVRRow : null
     },

--- a/workers/ff-pipeline/src/gascity/autonomy-monitor.test.ts
+++ b/workers/ff-pipeline/src/gascity/autonomy-monitor.test.ts
@@ -56,8 +56,14 @@ class MemoryDb {
     return edge
   }
 
-  async query<T = unknown>(aql: string, vars: Record<string, unknown> = {}): Promise<T[]> {
-    if (aql.includes("COLLECT state = fn.state")) {
+  // Wrap a doc in D1 row shape so parseRows() works
+  private wrap<T extends Record<string, unknown>>(doc: T): { json: string } {
+    return { json: JSON.stringify(doc) }
+  }
+
+  async query<T = unknown>(sql: string, params: unknown[] = []): Promise<T[]> {
+    // Aggregate: state counts
+    if (sql.includes("GROUP BY") && sql.includes("specs_functions")) {
       const counts = new Map<string, number>()
       for (const fn of this.collection("specs_functions").values()) {
         const stateValue = typeof fn.state === "string" ? fn.state : "unknown"
@@ -65,27 +71,9 @@ class MemoryDb {
       }
       return [...counts].map(([stateValue, count]) => ({ state: stateValue, count })) as T[]
     }
-    if (aql.includes('fn.state == "accepted"')) {
-      return [...this.collection("specs_functions").values()].filter((fn) => fn.state === "accepted") as T[]
-    }
-    if (aql.includes('fn.state == "monitored"')) {
-      return [...this.collection("specs_functions").values()].filter((fn) => fn.state === "monitored") as T[]
-    }
-    if (aql.includes("FROM persistence_verdicts") || aql.includes("FOR vr IN persistence_verdicts")) {
-      if (aql.includes("KEEP(vr")) return [...this.collection("persistence_verdicts").values()] as T[]
-      const functionId = vars.functionId
-      return [...this.collection("persistence_verdicts").values()]
-        .filter((vr) => vr.function_id === functionId)
-        .sort((a, b) => String(b.timestamp).localeCompare(String(a.timestamp))) as T[]
-    }
-    if (aql.includes("FOR dl IN dispatch_log")) {
-      const cutoff = String(vars.cutoff ?? "")
-      const completions = new Set([...this.collection("completion_events").values()].map((ce) => ce.bead_id))
-      return [...this.collection("dispatch_log").values()]
-        .filter((dl) => dl.outcome === "dispatched" && String(dl.started_at) < cutoff && !completions.has(dl.gc_bead_id)) as T[]
-    }
-    if (aql.includes("FOR inc IN specs_incidents") && aql.includes("COLLECT incidentType")) {
-      const threshold = Number(vars.threshold ?? 3)
+    // Aggregate: escalation groups
+    if (sql.includes("specs_incidents") && sql.includes("GROUP BY")) {
+      const threshold = Number(params[0] ?? 3)
       const groups = new Map<string, { incidentType: string; functionId: string; incidentIds: string[] }>()
       for (const inc of this.collection("specs_incidents").values()) {
         if (inc.status !== "open" || typeof inc.incidentType !== "string" || !inc.incidentType.startsWith("gascity_")) continue
@@ -98,27 +86,64 @@ class MemoryDb {
       }
       return [...groups.values()]
         .filter((group) => group.incidentIds.length >= threshold)
-        .map((group) => ({ ...group, count: group.incidentIds.length })) as T[]
+        .map((group) => ({ ...group, count: group.incidentIds.length, incidentIdsList: group.incidentIds.join(',') })) as T[]
     }
-    if (aql.includes("FOR inc IN specs_incidents")) return [...this.collection("specs_incidents").values()] as T[]
-    if (aql.includes("FOR prs IN specs_pressures")) return [...this.collection("specs_pressures").values()] as T[]
+    // Document queries — return { json } rows so parseRows() works
+    if (sql.includes("specs_functions") && sql.includes("'accepted'")) {
+      return [...this.collection("specs_functions").values()]
+        .filter((fn) => fn.state === "accepted")
+        .map(doc => this.wrap(doc)) as T[]
+    }
+    if (sql.includes("specs_functions") && sql.includes("'monitored'")) {
+      return [...this.collection("specs_functions").values()]
+        .filter((fn) => fn.state === "monitored")
+        .map(doc => this.wrap(doc)) as T[]
+    }
+    if (sql.includes("persistence_verdicts")) {
+      return [...this.collection("persistence_verdicts").values()]
+        .map(doc => this.wrap(doc)) as T[]
+    }
+    if (sql.includes("dispatch_log")) {
+      const cutoff = String(params[0] ?? "")
+      const completions = new Set([...this.collection("completion_events").values()].map((ce) => ce.bead_id))
+      return [...this.collection("dispatch_log").values()]
+        .filter((dl) => dl.outcome === "dispatched" && String(dl.started_at) < cutoff && !completions.has(dl.gc_bead_id))
+        .map(doc => this.wrap(doc)) as T[]
+    }
+    if (sql.includes("specs_incidents")) {
+      return [...this.collection("specs_incidents").values()]
+        .map(doc => this.wrap(doc)) as T[]
+    }
+    if (sql.includes("specs_pressures")) {
+      return [...this.collection("specs_pressures").values()]
+        .map(doc => this.wrap(doc)) as T[]
+    }
     return []
   }
 
-  async queryOne<T = unknown>(aql: string, vars: Record<string, unknown> = {}): Promise<T | null> {
-    if (aql.includes("FOR vr IN fidelity_verdicts")) {
-      const functionId = vars.functionId
-      return ([...this.collection("fidelity_verdicts").values()]
+  async queryOne<T = unknown>(sql: string, params: unknown[] = []): Promise<T | null> {
+    if (sql.includes("fidelity_verdicts")) {
+      const functionId = params[0] as string
+      const found = [...this.collection("fidelity_verdicts").values()]
         .filter((vr) => vr.function_id === functionId && vr.overall === "pass")
-        .sort((a, b) => String(b.received_at).localeCompare(String(a.received_at)))[0] ?? null) as T | null
+        .sort((a, b) => String(b.received_at).localeCompare(String(a.received_at)))[0]
+      return (found ? this.wrap(found) : null) as T | null
     }
-    if (aql.includes("FOR ce IN completion_events")) {
-      const functionId = vars.functionId
-      return ([...this.collection("completion_events").values()]
+    if (sql.includes("completion_events")) {
+      const functionId = params[0] as string
+      const found = [...this.collection("completion_events").values()]
         .filter((ce) => ce.fn_id === functionId)
-        .sort((a, b) => String(b.received_at).localeCompare(String(a.received_at)))[0] ?? null) as T | null
+        .sort((a, b) => String(b.received_at).localeCompare(String(a.received_at)))[0]
+      return (found ? this.wrap(found) : null) as T | null
     }
-    const rows = await this.query<T>(aql, vars)
+    if (sql.includes("persistence_verdicts")) {
+      const functionId = params[0] as string
+      const found = [...this.collection("persistence_verdicts").values()]
+        .filter((vr) => vr.function_id === functionId)
+        .sort((a, b) => String(b.timestamp).localeCompare(String(a.timestamp)))[0]
+      return (found ? this.wrap(found) : null) as T | null
+    }
+    const rows = await this.query<T>(sql, params)
     return rows[0] ?? null
   }
 }

--- a/workers/ff-pipeline/src/gascity/autonomy-monitor.ts
+++ b/workers/ff-pipeline/src/gascity/autonomy-monitor.ts
@@ -17,11 +17,19 @@ interface AutonomyDb {
     },
   ): Promise<void>
   get<T = unknown>(collection: string, key: string): Promise<T | null>
-  query<T = unknown>(aql: string, vars?: Record<string, unknown>): Promise<T[]>
-  queryOne<T = unknown>(aql: string, vars?: Record<string, unknown>): Promise<T | null>
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>
+  queryOne<T = unknown>(sql: string, params?: unknown[]): Promise<T | null>
   save<T = unknown>(collection: string, doc: Record<string, unknown>): Promise<T>
   update<T = unknown>(collection: string, key: string, patch: Record<string, unknown>): Promise<T>
   saveEdge(collection: string, from: string, to: string, data: Record<string, unknown>): Promise<unknown>
+}
+
+// Parse json rows returned by D1 document queries
+function parseRows<T>(rows: { json: string }[]): T[] {
+  return rows.map(r => JSON.parse(r.json) as T)
+}
+function parseRow<T>(row: { json: string } | null): T | null {
+  return row ? JSON.parse(row.json) as T : null
 }
 
 interface FunctionRecord {
@@ -113,26 +121,20 @@ export async function runGasCityAutonomyMonitor(
   // full monitor sweep to keep response time tight and predictable.
   if (trigger === "smoke") {
     const ping = await queryWithTimeout(
-      db.query<{ ok: number }>("RETURN { ok: 1 }"),
+      db.query<{ ok: number }>("SELECT 1 AS ok"),
       [] as Array<{ ok: number }>,
       5000,
     )
     if (ping.length === 0) {
-      return {
-        ...summary,
-        ok: false,
-      }
+      return { ...summary, ok: false }
     }
     return summary
   }
 
   const accepted = await queryWithTimeout(
-    db.query<FunctionRecord>(
-    `FOR fn IN specs_functions
-       FILTER fn.state == "accepted"
-       LIMIT 100
-       RETURN fn`,
-    ),
+    db.query<{ json: string }>(
+      `SELECT json FROM documents WHERE collection='specs_functions' AND json_extract(json,'$.state')='accepted' LIMIT 100`,
+    ).then(rows => parseRows<FunctionRecord>(rows)),
     [] as FunctionRecord[],
     8000,
   )
@@ -159,12 +161,9 @@ export async function runGasCityAutonomyMonitor(
   }
 
   const monitored = await queryWithTimeout(
-    db.query<FunctionRecord>(
-    `FOR fn IN specs_functions
-       FILTER fn.state == "monitored"
-       LIMIT 100
-       RETURN fn`,
-    ),
+    db.query<{ json: string }>(
+      `SELECT json FROM documents WHERE collection='specs_functions' AND json_extract(json,'$.state')='monitored' LIMIT 100`,
+    ).then(rows => parseRows<FunctionRecord>(rows)),
     [] as FunctionRecord[],
     8000,
   )
@@ -197,21 +196,19 @@ export async function runGasCityAutonomyMonitor(
   }
 
   const staleDispatches = await queryWithTimeout(
-    db.query<Record<string, unknown>>(
-    `FOR dl IN dispatch_log
-       FILTER dl.outcome == "dispatched"
-       FILTER dl.started_at < @cutoff
-       LET completion = FIRST(
-         FOR ce IN completion_events
-         FILTER ce.bead_id == dl.gc_bead_id
-         LIMIT 1
-         RETURN ce
-       )
-       FILTER completion == null
-       LIMIT 100
-       RETURN dl`,
-    { cutoff: staleDispatchCutoff },
-    ),
+    db.query<{ json: string }>(
+      `SELECT d.json FROM documents d
+       WHERE d.collection='dispatch_log'
+         AND json_extract(d.json,'$.outcome')='dispatched'
+         AND json_extract(d.json,'$.started_at') < ?
+         AND NOT EXISTS (
+           SELECT 1 FROM documents ce
+           WHERE ce.collection='completion_events'
+             AND json_extract(ce.json,'$.bead_id')=json_extract(d.json,'$.gc_bead_id')
+         )
+       LIMIT 100`,
+      [staleDispatchCutoff],
+    ).then(rows => parseRows<Record<string, unknown>>(rows)),
     [] as Record<string, unknown>[],
     8000,
   )
@@ -231,42 +228,36 @@ export async function getGasCityAutonomyStatus(env: PipelineEnv): Promise<Record
   const [states, recentPersistence, openIncidents, pressures] = await Promise.all([
     queryWithTimeout(
       db.query<{ state: string; count: number }>(
-      `FOR fn IN specs_functions
-         COLLECT state = fn.state WITH COUNT INTO count
-         RETURN { state, count }`,
+        `SELECT json_extract(json,'$.state') as state, COUNT(*) as count
+         FROM documents WHERE collection='specs_functions'
+         GROUP BY json_extract(json,'$.state')`,
       ),
       [],
       6000,
     ),
     queryWithTimeout(
-      db.query<Record<string, unknown>>(
-      `FOR vr IN persistence_verdicts
-         SORT vr.timestamp DESC
-         LIMIT 10
-         RETURN KEEP(vr, ["id", "function_id", "overall", "timestamp", "remediation"])`,
-      ),
+      db.query<{ json: string }>(
+        `SELECT json FROM documents WHERE collection='persistence_verdicts'
+         ORDER BY json_extract(json,'$.timestamp') DESC LIMIT 10`,
+      ).then(rows => parseRows<Record<string, unknown>>(rows)),
       [],
       6000,
     ),
     queryWithTimeout(
-      db.query<Record<string, unknown>>(
-      `FOR inc IN specs_incidents
-         FILTER inc.status == "open"
-         SORT inc.openedAt DESC
-         LIMIT 10
-         RETURN KEEP(inc, ["id", "incidentType", "functionIds", "severity", "openedAt", "title"])`,
-      ),
+      db.query<{ json: string }>(
+        `SELECT json FROM documents WHERE collection='specs_incidents'
+         AND json_extract(json,'$.status')='open'
+         ORDER BY json_extract(json,'$.openedAt') DESC LIMIT 10`,
+      ).then(rows => parseRows<Record<string, unknown>>(rows)),
       [],
       6000,
     ),
     queryWithTimeout(
-      db.query<Record<string, unknown>>(
-      `FOR prs IN specs_pressures
-         FILTER STARTS_WITH(prs.id, "PRS-OPS-GC-")
-         SORT prs.createdAt DESC
-         LIMIT 10
-         RETURN KEEP(prs, ["id", "name", "urgency", "strength", "createdAt"])`,
-      ),
+      db.query<{ json: string }>(
+        `SELECT json FROM documents WHERE collection='specs_pressures'
+         AND json_extract(json,'$.id') LIKE 'PRS-OPS-GC-%'
+         ORDER BY json_extract(json,'$.createdAt') DESC LIMIT 10`,
+      ).then(rows => parseRows<Record<string, unknown>>(rows)),
       [],
       6000,
     ),
@@ -353,23 +344,19 @@ async function evaluateFunctionPersistence(
   freshnessCutoff: Date,
   timestamp: string,
 ): Promise<{ overall: "pass" | "fail"; reportId: string; reportWritten: boolean }> {
-  const fidelity = await db.queryOne<FidelityRecord>(
-    `FOR vr IN fidelity_verdicts
-       FILTER vr.function_id == @functionId
-       FILTER vr.overall == "pass"
-       SORT vr.received_at DESC
-       LIMIT 1
-       RETURN vr`,
-    { functionId },
-  )
-  const completion = await db.queryOne<CompletionEventRecord>(
-    `FOR ce IN completion_events
-       FILTER ce.fn_id == @functionId
-       SORT ce.received_at DESC
-       LIMIT 1
-       RETURN ce`,
-    { functionId },
-  )
+  const fidelity = await db.queryOne<{ json: string }>(
+    `SELECT json FROM documents WHERE collection='fidelity_verdicts'
+     AND json_extract(json,'$.function_id')=?
+     AND json_extract(json,'$.overall')='pass'
+     ORDER BY json_extract(json,'$.received_at') DESC LIMIT 1`,
+    [functionId],
+  ).then(row => parseRow<FidelityRecord>(row))
+  const completion = await db.queryOne<{ json: string }>(
+    `SELECT json FROM documents WHERE collection='completion_events'
+     AND json_extract(json,'$.fn_id')=?
+     ORDER BY json_extract(json,'$.received_at') DESC LIMIT 1`,
+    [functionId],
+  ).then(row => parseRow<CompletionEventRecord>(row))
   const fresh = !!fidelity && !!completion && isFresh(isoValue(fidelity.received_at ?? fidelity.timestamp), freshnessCutoff) && isFresh(isoValue(completion.received_at), freshnessCutoff)
   const report = await writePersistenceReport(db, {
     functionId,
@@ -383,14 +370,12 @@ async function evaluateFunctionPersistence(
 }
 
 async function latestPersistenceReport(db: AutonomyDb, functionId: string): Promise<Record<string, unknown> | null> {
-  return db.queryOne<Record<string, unknown>>(
-    `FOR vr IN persistence_verdicts
-       FILTER vr.function_id == @functionId
-       SORT vr.timestamp DESC
-       LIMIT 1
-       RETURN vr`,
-    { functionId },
-  )
+  return db.queryOne<{ json: string }>(
+    `SELECT json FROM documents WHERE collection='persistence_verdicts'
+     AND json_extract(json,'$.function_id')=?
+     ORDER BY json_extract(json,'$.timestamp') DESC LIMIT 1`,
+    [functionId],
+  ).then(row => parseRow<Record<string, unknown>>(row))
 }
 
 async function writePersistenceReport(
@@ -517,19 +502,27 @@ async function writeDispatchStaleIncident(
 }
 
 async function escalateRecurringIncidents(db: AutonomyDb, timestamp: string, threshold: number): Promise<number> {
-  const groups = await db.query<{ incidentType: string; functionId: string; count: number; incidentIds: string[] }>(
-    `FOR inc IN specs_incidents
-       FILTER inc.status == "open"
-       FILTER STARTS_WITH(inc.incidentType, "gascity_")
-       LET fnId = LENGTH(inc.functionIds) > 0 ? inc.functionIds[0] : "FN-GC-DISPATCH-WIRE"
-       COLLECT incidentType = inc.incidentType, functionId = fnId INTO grouped = inc
-       LET incidentIds = grouped[*].id
-       FILTER LENGTH(incidentIds) >= @threshold
-       RETURN { incidentType, functionId, count: LENGTH(incidentIds), incidentIds }`,
-    { threshold },
+  const groups = await db.query<{ incidentType: string; functionId: string; count: number; incidentIdsList: string }>(
+    `SELECT
+       json_extract(json,'$.incidentType') as incidentType,
+       COALESCE(json_extract(json,'$.functionIds[0]'), 'FN-GC-DISPATCH-WIRE') as functionId,
+       COUNT(*) as count,
+       GROUP_CONCAT(json_extract(json,'$.id')) as incidentIdsList
+     FROM documents
+     WHERE collection='specs_incidents'
+       AND json_extract(json,'$.status')='open'
+       AND json_extract(json,'$.incidentType') LIKE 'gascity_%'
+     GROUP BY json_extract(json,'$.incidentType'), functionId
+     HAVING COUNT(*) >= ?`,
+    [threshold],
   )
+  // Reshape to match expected interface (incidentIdsList → incidentIds array)
+  const typedGroups = groups.map(g => ({
+    ...g,
+    incidentIds: g.incidentIdsList ? g.incidentIdsList.split(',') : [],
+  }))
   let created = 0
-  for (const group of groups) {
+  for (const group of typedGroups) {
     const id = `PRS-OPS-GC-${(await sha256Hex(`${group.incidentType}|${group.functionId}`)).slice(0, 12).toUpperCase()}`
     const pressure = Pressure.parse({
       id,


### PR DESCRIPTION
## Summary

- **autonomy-monitor.ts**: convert all AQL to SQL (smoke ping → `SELECT 1 AS ok`, function state queries, stale dispatch LEFT JOIN, GROUP BY state counts, escalation group aggregates)
- **formula-compiler-adapter.ts**: replace `json_each` EXISTS subquery with `LIKE` — D1 does not support `json_each` in correlated subqueries
- **ontology-loader**: same `json_each` → `LIKE` fix for `getConstraintsForClass`
- Update all test mocks to match new SQL patterns and D1 `{ json: string }` row shape

## Validated
- Smoke test PASSED end-to-end: `trace_id: 0cf002d2-1dbe-4187-be3b-875c567a6b10`
- All 1029 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)