### PR TITLE
feat: implement IS-GC-CONTAINER-KEEPALIVE keepalive wiring in ff-pipeline

### DIFF
--- a/workers/ff-pipeline/src/gascity/webhook-receiver.ts
+++ b/workers/ff-pipeline/src/gascity/webhook-receiver.ts
@@ -219,6 +219,12 @@ export async function handleGasCityWebhook(request: Request, env: PipelineEnv): 
     const maxAmendmentDepth = configuredMaxAmendmentDepth(env)
     if (payload.factory_attempt > maxAmendmentDepth) {
       const incidentId = await writeAmendmentDepthIncident(db, payload, vrId, remediation, receivedAt, maxAmendmentDepth)
+      // Best-effort keepalive stop on halted-amendment path
+      fetch(`${env.GAS_CITY_BASE_URL}/v0/keepalive/stop`, {
+        method: "POST",
+        headers: { "Authorization": `Bearer ${env.GAS_CITY_BEARER_TOKEN}` },
+        signal: AbortSignal.timeout(5_000),
+      }).catch(() => {})
       return json({
         accepted: true,
         vr_id: vrId,


### PR DESCRIPTION
## Summary

Implements [IS-GC-CONTAINER-KEEPALIVE](../specs/IS-GC-CONTAINER-KEEPALIVE.md) Changes 2 & 3:

- **formula-compiler.ts** — fire `POST /v0/keepalive/start` (fire-and-forget, 5s timeout) before `return { outcome: "dispatched" }` in `dispatchCall3AndFinalize`
- **webhook-receiver.ts** — fire `POST /v0/keepalive/stop` on the successful RELEASE path AND on the `amendment_halted` early return path (Architect catch: missing from early return would leave `keepalive_active=true` indefinitely)

Change 1 (GasCitySupervisor → Container base class) lives in the eai/weops-gascity repo and is committed separately.

## Why
Without keepalive, the GasCitySupervisor DO evicts after ~30s inactivity, killing the Container mid-LLM-call. Plan and code steps fail with `provider_execution_not_completed` on every live Gas City workflow.

## Test plan
- [ ] CI passes
- [ ] Post-deploy: full Gas City workflow completes (init → plan → code → verify → release → finalize)

🤖 Generated with [Claude Code](https://claude.com/claude-code)