### PR TITLE
fix(supervisor): async onStop prevents stale keepalive_refcount loop

### DIFF
--- a/workers/gascity-supervisor/src/index.ts
+++ b/workers/gascity-supervisor/src/index.ts
@@ -36,8 +36,8 @@ export class GasCitySupervisor extends Container<Env> {
     await super.onActivityExpired();
   }
 
-  override onStop(): void {
-    this.ctx.storage.delete("keepalive_refcount").catch(() => {});
+  override async onStop(): Promise<void> {
+    await this.ctx.storage.delete("keepalive_refcount").catch(() => {});
   }
 
   override async fetch(request: Request): Promise<Response> {


### PR DESCRIPTION
## Summary

`onStop()` was `void` with a fire-and-forget storage delete. If the delete failed silently on container crash, `keepalive_refcount` stayed non-zero and `onActivityExpired` would loop `renewActivityTimeout()` indefinitely.

Fix: `override async onStop(): Promise<void>` + `await` the storage delete.

Part of IS-GC-CONTAINER-KEEPALIVE — companion to #84 (ff-pipeline keepalive wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)